### PR TITLE
fix(Python): ease python binding generation

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -20,6 +20,12 @@
 
 find_package(pybind11 REQUIRED CONFIG NO_DEFAULT_PATH PATHS ${PYBIND11_INSTALL_PREFIX})
 
+install(
+    DIRECTORY
+        ${PYBIND11_INSTALL_PREFIX}/
+    DESTINATION
+        .
+)
 add_subdirectory(src)
 
 if(OPENGEODE_WITH_TESTS)

--- a/bindings/python/src/basic/basic.cpp
+++ b/bindings/python/src/basic/basic.cpp
@@ -46,7 +46,7 @@ namespace pybind11
     } // namespace detail
 } // namespace pybind11
 
-PYBIND11_MODULE( OpenGeode_py_basic, module )
+PYBIND11_MODULE( opengeode_py_basic, module )
 {
     module.doc() = "OpenGeode Python binding for basic";
     module.attr( "NO_ID" ) = geode::NO_ID;

--- a/bindings/python/src/geometry/geometry.cpp
+++ b/bindings/python/src/geometry/geometry.cpp
@@ -41,7 +41,7 @@ namespace pybind11
     } // namespace detail
 } // namespace pybind11
 
-PYBIND11_MODULE( OpenGeode_py_geometry, module )
+PYBIND11_MODULE( opengeode_py_geometry, module )
 {
     module.doc() = "OpenGeode Python binding for geometry";
     geode::define_point( module );

--- a/bindings/python/src/mesh/mesh.cpp
+++ b/bindings/python/src/mesh/mesh.cpp
@@ -69,7 +69,7 @@ namespace pybind11
     } // namespace detail
 } // namespace pybind11
 
-PYBIND11_MODULE( OpenGeode_py_mesh, module )
+PYBIND11_MODULE( opengeode_py_mesh, module )
 {
     module.doc() = "OpenGeode Python binding for mesh";
     geode::define_vertex_set( module );

--- a/bindings/python/src/model/model.cpp
+++ b/bindings/python/src/model/model.cpp
@@ -70,7 +70,7 @@ namespace pybind11
     } // namespace detail
 } // namespace pybind11
 
-PYBIND11_MODULE( OpenGeode_py_model, module )
+PYBIND11_MODULE( opengeode_py_model, module )
 {
     module.doc() = "OpenGeode Python binding for model";
     geode::define_component_type( module );

--- a/bindings/python/tests/basic/test-py-attribute.py
+++ b/bindings/python/tests/basic/test-py-attribute.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
+import opengeode_py_basic as basic
 
 def test_constant_attribute( manager ):
     constant_attribute = manager.find_or_create_attribute_constant_bool( "bool", True )

--- a/bindings/python/tests/basic/test-py-uuid.py
+++ b/bindings/python/tests/basic/test-py-uuid.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
+import opengeode_py_basic as basic
 
 if __name__ == '__main__':
     id = basic.uuid()

--- a/bindings/python/tests/geometry/test-py-bounding-box.py
+++ b/bindings/python/tests/geometry/test-py-bounding-box.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_geometry as geom
+import opengeode_py_geometry as geom
 
 if __name__ == '__main__':
     box = geom.BoundingBox2D()

--- a/bindings/python/tests/geometry/test-py-nnsearch.py
+++ b/bindings/python/tests/geometry/test-py-nnsearch.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_geometry as geom
+import opengeode_py_geometry as geom
 
 if __name__ == '__main__':
     search = geom.NNSearch2D( [geom.Point2D( [0.1, 4.2] ), geom.Point2D( [5.9, 7.3] ), geom.Point2D( [1.8, -5] ), geom.Point2D( [ -7.3, -1.6] )] )

--- a/bindings/python/tests/geometry/test-py-point.py
+++ b/bindings/python/tests/geometry/test-py-point.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_geometry as geom
+import opengeode_py_geometry as geom
 
 def test_comparison():
     p = geom.Point3D( [2, 1.0, 2.6] )

--- a/bindings/python/tests/geometry/test-py-vector.py
+++ b/bindings/python/tests/geometry/test-py-vector.py
@@ -21,7 +21,7 @@
 
 import math
 
-import OpenGeode_py_geometry as geom
+import opengeode_py_geometry as geom
 
 def test_length():
     p = geom.Vector3D( [1, 2, 4] )

--- a/bindings/python/tests/mesh/test-py-edged-curve.py
+++ b/bindings/python/tests/mesh/test-py-edged-curve.py
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic
-import OpenGeode_py_geometry as geom
-import OpenGeode_py_mesh as mesh
+import opengeode_py_basic
+import opengeode_py_geometry as geom
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( edged_curve, builder ):
     builder.create_point( geom.Point3D( [ 0.1, 0.2, 0.3 ] ) )

--- a/bindings/python/tests/mesh/test-py-graph.py
+++ b/bindings/python/tests/mesh/test-py-graph.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_mesh as mesh
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( graph, builder ):
     builder.create_vertex()

--- a/bindings/python/tests/mesh/test-py-point-set.py
+++ b/bindings/python/tests/mesh/test-py-point-set.py
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic
-import OpenGeode_py_geometry as geom
-import OpenGeode_py_mesh as mesh
+import opengeode_py_basic
+import opengeode_py_geometry as geom
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( point_set, builder ):
     builder.create_point( geom.Point3D( [ 0.1, 0.2, 0.3 ] ) )

--- a/bindings/python/tests/mesh/test-py-polygonal-surface.py
+++ b/bindings/python/tests/mesh/test-py-polygonal-surface.py
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
-import OpenGeode_py_geometry as geom
-import OpenGeode_py_mesh as mesh
+import opengeode_py_basic as basic
+import opengeode_py_geometry as geom
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( polygonal_surface, builder ):
     builder.create_point( geom.Point3D( [ 0.1, 0.2, 0.3 ] ) )

--- a/bindings/python/tests/mesh/test-py-polyhedral-solid.py
+++ b/bindings/python/tests/mesh/test-py-polyhedral-solid.py
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
-import OpenGeode_py_geometry as geom
-import OpenGeode_py_mesh as mesh
+import opengeode_py_basic as basic
+import opengeode_py_geometry as geom
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( polyhedral_solid, builder ):
     builder.create_point( geom.Point3D( [ 0.1, 0.2, 0.3 ] ) )

--- a/bindings/python/tests/mesh/test-py-tetrahedral-solid.py
+++ b/bindings/python/tests/mesh/test-py-tetrahedral-solid.py
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
-import OpenGeode_py_geometry as geom
-import OpenGeode_py_mesh as mesh
+import opengeode_py_basic as basic
+import opengeode_py_geometry as geom
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( solid, builder ):
     builder.create_point( geom.Point3D( [ 0.1, 0.2, 0.3 ] ) )

--- a/bindings/python/tests/mesh/test-py-triangulated-surface.py
+++ b/bindings/python/tests/mesh/test-py-triangulated-surface.py
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
-import OpenGeode_py_geometry as geom
-import OpenGeode_py_mesh as mesh
+import opengeode_py_basic as basic
+import opengeode_py_geometry as geom
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( surface, builder ):
     builder.create_point( geom.Point3D( [ 0.1, 0.2, 0.3 ] ) )

--- a/bindings/python/tests/mesh/test-py-vertex-set.py
+++ b/bindings/python/tests/mesh/test-py-vertex-set.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_mesh as mesh
+import opengeode_py_mesh as mesh
 
 def test_create_vertices( vertex_set, builder ):
     builder.create_vertex()

--- a/bindings/python/tests/model/test-py-brep.py
+++ b/bindings/python/tests/model/test-py-brep.py
@@ -19,8 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
-import OpenGeode_py_model as model
+import opengeode_py_basic as basic
+import opengeode_py_model as model
 
 def find_uuid_in_list( uuids, uuid ):
     for cur_uuid in uuids:

--- a/bindings/python/tests/model/test-py-section.py
+++ b/bindings/python/tests/model/test-py-section.py
@@ -19,8 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import OpenGeode_py_basic as basic
-import OpenGeode_py_model as model
+import opengeode_py_basic as basic
+import opengeode_py_model as model
 
 def find_uuid_in_list( uuids, uuid ):
     for cur_uuid in uuids:

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -269,6 +269,7 @@ function(add_geode_test)
 endfunction()
 
 function(add_geode_python_binding)
+    find_package(pybind11 REQUIRED)
     cmake_parse_arguments(GEODE_BINDING
         ""
         "NAME"
@@ -282,9 +283,11 @@ function(add_geode_python_binding)
     target_link_libraries(${GEODE_BINDING_NAME} 
         PRIVATE "${GEODE_BINDING_DEPENDENCIES}"
     )
+    string(TOLOWER ${PROJECT_NAME} project-name)
+    string(REGEX REPLACE "-" "_" project_name ${project-name})
     set_target_properties(${GEODE_BINDING_NAME}
         PROPERTIES
-            OUTPUT_NAME ${PROJECT_NAME}_${GEODE_BINDING_NAME}
+            OUTPUT_NAME ${project_name}_${GEODE_BINDING_NAME}
             CXX_VISIBILITY_PRESET "default"
             FOLDER "Bindings/Python"
     )


### PR DESCRIPTION
Python recommends to use lowercase module names without dash.