### PR TITLE
fix(Mesh): better isolated methods naming

### DIFF
--- a/bindings/python/src/mesh/core/graph.h
+++ b/bindings/python/src/mesh/core/graph.h
@@ -40,7 +40,8 @@ namespace geode
             .def( "nb_edges", &Graph::nb_edges )
             .def( "edge_attribute_manager", &Graph::edge_attribute_manager,
                 pybind11::return_value_policy::reference )
-            .def( "edges_around_vertex", &Graph::edges_around_vertex );
+            .def( "edges_around_vertex", &Graph::edges_around_vertex )
+            .def( "is_vertex_isolated", &Graph::is_vertex_isolated );
 
         pybind11::class_< EdgeVertex >( module, "EdgeVertex" )
             .def( pybind11::init<>() )

--- a/include/geode/mesh/core/detail/facet_edges_impl.h
+++ b/include/geode/mesh/core/detail/facet_edges_impl.h
@@ -90,7 +90,7 @@ namespace geode
                 return this->clean_facets();
             }
 
-            bool isolated_edge( index_t edge_id ) const
+            bool is_edge_isolated( index_t edge_id ) const
             {
                 return this->get_counter( edge_id ) == 0;
             }

--- a/include/geode/mesh/core/detail/solid_mesh_view_impl.h
+++ b/include/geode/mesh/core/detail/solid_mesh_view_impl.h
@@ -111,7 +111,7 @@ namespace geode
                 return absl::nullopt;
             }
 
-            bool get_isolated_edge( index_t edge_id ) const
+            bool get_is_edge_isolated( index_t edge_id ) const
             {
                 const auto& vertices = solid_view_.edge_vertices( edge_id );
                 for( const auto& polyhedron_vertex :
@@ -156,7 +156,7 @@ namespace geode
                 return true;
             }
 
-            bool get_isolated_facet( index_t facet_id ) const
+            bool get_is_facet_isolated( index_t facet_id ) const
             {
                 using Cycle = detail::VertexCycle< PolyhedronFacetVertices >;
                 const auto& vertices = solid_view_.facet_vertices( facet_id );

--- a/include/geode/mesh/core/graph.h
+++ b/include/geode/mesh/core/graph.h
@@ -133,6 +133,8 @@ namespace geode
          */
         const EdgesAroundVertex& edges_around_vertex( index_t vertex_id ) const;
 
+        bool is_vertex_isolated( index_t vertex_id ) const;
+
         absl::optional< index_t > edge_from_vertices(
             index_t v0, index_t v1 ) const;
 

--- a/include/geode/mesh/core/solid_edges.h
+++ b/include/geode/mesh/core/solid_edges.h
@@ -57,7 +57,7 @@ namespace geode
 
         index_t nb_edges() const;
 
-        bool isolated_edge( index_t edge_id ) const;
+        bool is_edge_isolated( index_t edge_id ) const;
 
         /*!
          * Return the indices of edge vertices.

--- a/include/geode/mesh/core/solid_facets.h
+++ b/include/geode/mesh/core/solid_facets.h
@@ -51,7 +51,7 @@ namespace geode
 
         index_t nb_facets() const;
 
-        bool isolated_facet( index_t facet_id ) const;
+        bool is_facet_isolated( index_t facet_id ) const;
 
         /*!
          * Return the indices of facet vertices.

--- a/include/geode/mesh/core/solid_mesh.h
+++ b/include/geode/mesh/core/solid_mesh.h
@@ -201,7 +201,7 @@ namespace geode
 
         index_t nb_polyhedra() const;
 
-        bool isolated_vertex( index_t vertex_id ) const;
+        bool is_vertex_isolated( index_t vertex_id ) const;
 
         /*!
          * Return the number of vertices in a polyhedron.

--- a/include/geode/mesh/core/surface_edges.h
+++ b/include/geode/mesh/core/surface_edges.h
@@ -54,7 +54,7 @@ namespace geode
 
         index_t nb_edges() const;
 
-        bool isolated_edge( index_t edge_id ) const;
+        bool is_edge_isolated( index_t edge_id ) const;
 
         /*!
          * Return the indices of edge vertices.

--- a/include/geode/mesh/core/surface_mesh.h
+++ b/include/geode/mesh/core/surface_mesh.h
@@ -141,7 +141,7 @@ namespace geode
 
         index_t nb_polygons() const;
 
-        bool isolated_vertex( index_t vertex_id ) const;
+        bool is_vertex_isolated( index_t vertex_id ) const;
 
         /*!
          * Return the number of vertices in a polygon

--- a/src/geode/mesh/core/graph.cpp
+++ b/src/geode/mesh/core/graph.cpp
@@ -187,6 +187,11 @@ namespace geode
         return impl_->edges_around_vertex( vertex_id );
     }
 
+    bool Graph::is_vertex_isolated( index_t vertex_id ) const
+    {
+        return edges_around_vertex( vertex_id ).empty();
+    }
+
     absl::optional< index_t > Graph::edge_from_vertices(
         index_t v0, index_t v1 ) const
     {

--- a/src/geode/mesh/core/solid_edges.cpp
+++ b/src/geode/mesh/core/solid_edges.cpp
@@ -105,10 +105,10 @@ namespace geode
     }
 
     template < index_t dimension >
-    bool SolidEdges< dimension >::isolated_edge( index_t edge_id ) const
+    bool SolidEdges< dimension >::is_edge_isolated( index_t edge_id ) const
     {
         check_edge_id( *this, edge_id );
-        return impl_->isolated_edge( edge_id );
+        return impl_->is_edge_isolated( edge_id );
     }
 
     template < index_t dimension >

--- a/src/geode/mesh/core/solid_facets.cpp
+++ b/src/geode/mesh/core/solid_facets.cpp
@@ -125,7 +125,7 @@ namespace geode
             return this->clean_facets();
         }
 
-        bool isolated_facet( index_t facet_id ) const
+        bool is_facet_isolated( index_t facet_id ) const
         {
             return this->get_counter( facet_id ) == 0;
         }
@@ -170,10 +170,10 @@ namespace geode
     }
 
     template < index_t dimension >
-    bool SolidFacets< dimension >::isolated_facet( index_t facet_id ) const
+    bool SolidFacets< dimension >::is_facet_isolated( index_t facet_id ) const
     {
         check_facet_id( *this, facet_id );
-        return impl_->isolated_facet( facet_id );
+        return impl_->is_facet_isolated( facet_id );
     }
 
     template < index_t dimension >

--- a/src/geode/mesh/core/solid_mesh.cpp
+++ b/src/geode/mesh/core/solid_mesh.cpp
@@ -541,7 +541,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    bool SolidMesh< dimension >::isolated_vertex( index_t vertex_id ) const
+    bool SolidMesh< dimension >::is_vertex_isolated( index_t vertex_id ) const
     {
         check_vertex_id( *this, vertex_id );
         return !get_polyhedron_around_vertex( vertex_id );

--- a/src/geode/mesh/core/surface_edges.cpp
+++ b/src/geode/mesh/core/surface_edges.cpp
@@ -173,10 +173,10 @@ namespace geode
     }
 
     template < index_t dimension >
-    bool SurfaceEdges< dimension >::isolated_edge( index_t edge_id ) const
+    bool SurfaceEdges< dimension >::is_edge_isolated( index_t edge_id ) const
     {
         check_edge_id( *this, edge_id );
-        return impl_->isolated_edge( edge_id );
+        return impl_->is_edge_isolated( edge_id );
     }
 
     template < index_t dimension >

--- a/src/geode/mesh/core/surface_mesh.cpp
+++ b/src/geode/mesh/core/surface_mesh.cpp
@@ -399,7 +399,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    bool SurfaceMesh< dimension >::isolated_vertex( index_t vertex_id ) const
+    bool SurfaceMesh< dimension >::is_vertex_isolated( index_t vertex_id ) const
     {
         check_vertex_id( *this, vertex_id );
         return !get_polygon_around_vertex( vertex_id );

--- a/tests/mesh/test-hybrid-solid.cpp
+++ b/tests/mesh/test-hybrid-solid.cpp
@@ -53,7 +53,7 @@ void test_create_vertices( const geode::HybridSolid3D& hybrid_solid,
     builder.create_point( { { 1, 2, 1 } } );
     builder.create_point( { { 0, 2, 1 } } );
     builder.create_point( { { 1, 1, 2 } } );
-    OPENGEODE_EXCEPTION( hybrid_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( hybrid_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should be isolated before polyhedra creation" );
     OPENGEODE_EXCEPTION( hybrid_solid.nb_vertices() == 11,
         "[Test] HybridSolid should have 11 vertices" );
@@ -124,7 +124,7 @@ void test_create_polyhedra( const geode::HybridSolid3D& hybrid_solid,
         "[Test] HybridSolid should have 16 facets" );
     OPENGEODE_EXCEPTION( hybrid_solid.edges().nb_edges() == 22,
         "[Test] HybridSolid should have 22 edges" );
-    OPENGEODE_EXCEPTION( !hybrid_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( !hybrid_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should not be isolated after polyhedra creation" );
 }
 
@@ -382,7 +382,7 @@ void test_delete_all( const geode::HybridSolid3D& hybrid_solid,
 
     OPENGEODE_EXCEPTION( hybrid_solid.nb_vertices() == 10,
         "[Test] HybridSolid should have 10 vertices" );
-    OPENGEODE_EXCEPTION( hybrid_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( hybrid_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should be isolated after polyhedra deletion" );
     OPENGEODE_EXCEPTION( hybrid_solid.nb_polyhedra() == 0,
         "[Test] HybridSolid should have 0 polyhedron" );

--- a/tests/mesh/test-polygonal-surface-view.cpp
+++ b/tests/mesh/test-polygonal-surface-view.cpp
@@ -43,7 +43,7 @@ void test_create_vertices( const geode::PolygonalSurface3D& polygonal_surface,
     builder.create_point( { { 4.7, 2.1, 1.3 } } );
     builder.create_point( { { 9.3, 5.3, 6.7 } } );
     builder.create_point( { { 7.5, 4.2, 2.8 } } );
-    OPENGEODE_EXCEPTION( polygonal_surface.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( polygonal_surface.is_vertex_isolated( 0 ),
         "[Test] Vertices should be isolated before polygons creation" );
     OPENGEODE_EXCEPTION( polygonal_surface.nb_vertices() == 7,
         "[Test] PolygonalSurface should have 7 vertices" );
@@ -87,7 +87,7 @@ void test_create_polygons( const geode::PolygonalSurface3D& polygonal_surface,
     builder.create_polygon( { 0, 1, 2 } );
     builder.create_polygon( { 1, 3, 4, 2 } );
     builder.create_polygon( { 1, 5, 6, 3 } );
-    OPENGEODE_EXCEPTION( !polygonal_surface.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( !polygonal_surface.is_vertex_isolated( 0 ),
         "[Test] Vertices should not be isolated after polygons creation" );
     OPENGEODE_EXCEPTION( polygonal_surface.nb_polygons() == 3,
         "[Test] PolygonalSurface should have 3 polygons" );

--- a/tests/mesh/test-polygonal-surface.cpp
+++ b/tests/mesh/test-polygonal-surface.cpp
@@ -48,7 +48,7 @@ void test_create_vertices( const geode::PolygonalSurface3D& polygonal_surface,
     builder.create_point( { { 4.7, 2.1, 1.3 } } );
     builder.create_point( { { 9.3, 5.3, 6.7 } } );
     builder.create_point( { { 7.5, 4.2, 2.8 } } );
-    OPENGEODE_EXCEPTION( polygonal_surface.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( polygonal_surface.is_vertex_isolated( 0 ),
         "[Test] Vertices should be isolated before polygons creation" );
     OPENGEODE_EXCEPTION( polygonal_surface.nb_vertices() == 7,
         "[Test] PolygonalSurface should have 7 vertices" );
@@ -219,7 +219,7 @@ void test_create_polygons( const geode::PolygonalSurface3D& polygonal_surface,
     builder.create_polygon( { 0, 1, 2 } );
     builder.create_polygon( { 1, 3, 4, 2 } );
     builder.create_polygon( { 1, 5, 6, 3 } );
-    OPENGEODE_EXCEPTION( !polygonal_surface.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( !polygonal_surface.is_vertex_isolated( 0 ),
         "[Test] Vertices should not be isolated after polygons creation" );
     OPENGEODE_EXCEPTION( polygonal_surface.nb_polygons() == 3,
         "[Test] PolygonalSurface should have 3 polygons" );
@@ -341,7 +341,8 @@ void test_delete_polygon( const geode::PolygonalSurface3D& polygonal_surface,
         "[Test] PolygonalSurface edge vertex index is not correct" );
     const auto isol_edge =
         polygonal_surface.edges().edge_from_vertices( { 1, 5 } ).value();
-    OPENGEODE_EXCEPTION( polygonal_surface.edges().isolated_edge( isol_edge ),
+    OPENGEODE_EXCEPTION(
+        polygonal_surface.edges().is_edge_isolated( isol_edge ),
         "[Test] Edge should be isolated after polygon deletion" );
     builder.edges_builder().delete_isolated_edges();
     OPENGEODE_EXCEPTION( polygonal_surface.edges().nb_edges() == 3,
@@ -545,7 +546,7 @@ void test_replace_vertex( const geode::PolygonalSurface3D& polygonal_surface,
         OPENGEODE_EXCEPTION( polygonal_surface.polygon_vertex( pv ) == new_id,
             "[Test] PolygonVertex after replace_vertex is wrong" );
     }
-    OPENGEODE_EXCEPTION( polygonal_surface.isolated_vertex( 1 ),
+    OPENGEODE_EXCEPTION( polygonal_surface.is_vertex_isolated( 1 ),
         "[Test] Isolated vertex after replace_vertex is wrong" );
     builder.replace_vertex( new_id, 1 );
     for( const auto& pv : polygons_around )

--- a/tests/mesh/test-polyhedral-solid-view.cpp
+++ b/tests/mesh/test-polyhedral-solid-view.cpp
@@ -41,7 +41,7 @@ void test_create_vertices( const geode::PolyhedralSolid3D& polyhedral_solid,
     builder.create_point( { { 9.3, 5.3, 6.7 } } );
     builder.create_point( { { 7.5, 4.2, 2.8 } } );
     builder.create_point( { { 2.2, 3.3, 4.4 } } );
-    OPENGEODE_EXCEPTION( polyhedral_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( polyhedral_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should be isolated before polyhedra creation" );
     OPENGEODE_EXCEPTION( polyhedral_solid.nb_vertices() == 8,
         "[Test] PolyhedralSolid should have 8 vertices" );
@@ -92,7 +92,7 @@ void test_create_polyhedra( const geode::PolyhedralSolid3D& polyhedral_solid,
         { { 1, 3, 2 }, { 0, 2, 3 }, { 3, 1, 0 }, { 0, 1, 2 } } );
     OPENGEODE_EXCEPTION( polyhedral_solid.nb_polyhedra() == 3,
         "[Test] PolyhedralSolid should have 3 polyhedra" );
-    OPENGEODE_EXCEPTION( !polyhedral_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( !polyhedral_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should not be isolated after polyhedra creation" );
 }
 

--- a/tests/mesh/test-polyhedral-solid.cpp
+++ b/tests/mesh/test-polyhedral-solid.cpp
@@ -50,7 +50,7 @@ void test_create_vertices( const geode::PolyhedralSolid3D& polyhedral_solid,
     builder.create_point( { { 9.3, 5.3, 6.7 } } );
     builder.create_point( { { 7.5, 4.2, 2.8 } } );
     builder.create_point( { { 2.2, 3.3, 4.4 } } );
-    OPENGEODE_EXCEPTION( polyhedral_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( polyhedral_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should be isolated before polyhedra creation" );
     OPENGEODE_EXCEPTION( polyhedral_solid.nb_vertices() == 8,
         "[Test] PolyhedralSolid should have 8 vertices" );
@@ -101,7 +101,7 @@ void test_create_polyhedra( const geode::PolyhedralSolid3D& polyhedral_solid,
         "[Test] PolyhedralSolid should have 11 facets" );
     OPENGEODE_EXCEPTION( polyhedral_solid.edges().nb_edges() == 15,
         "[Test] PolyhedralSolid should have 15 edges" );
-    OPENGEODE_EXCEPTION( !polyhedral_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( !polyhedral_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should not be isolated after polyhedra creation" );
 
     OPENGEODE_EXCEPTION(
@@ -514,15 +514,15 @@ void test_set_polyhedron_vertex(
     const auto facet_id = polyhedral_solid.facets().facet_from_vertices(
         polyhedral_solid.polyhedron_facet_vertices( { 0, 1 } ) );
     builder.set_polyhedron_vertex( { 0, 2 }, 2 );
-    OPENGEODE_EXCEPTION( polyhedral_solid.facets().isolated_facet( 0 ),
+    OPENGEODE_EXCEPTION( polyhedral_solid.facets().is_facet_isolated( 0 ),
         "[Test] Facet should be isolated before clean" );
-    OPENGEODE_EXCEPTION( polyhedral_solid.edges().isolated_edge( 0 ),
+    OPENGEODE_EXCEPTION( polyhedral_solid.edges().is_edge_isolated( 0 ),
         "[Test] Edge should be isolated before clean" );
     builder.facets_builder().delete_isolated_facets();
     builder.edges_builder().delete_isolated_edges();
-    OPENGEODE_EXCEPTION( !polyhedral_solid.facets().isolated_facet( 0 ),
+    OPENGEODE_EXCEPTION( !polyhedral_solid.facets().is_facet_isolated( 0 ),
         "[Test] Facet should not be isolated after clean" );
-    OPENGEODE_EXCEPTION( !polyhedral_solid.edges().isolated_edge( 0 ),
+    OPENGEODE_EXCEPTION( !polyhedral_solid.edges().is_edge_isolated( 0 ),
         "[Test] Edge should not be isolated after clean" );
 
     OPENGEODE_EXCEPTION( polyhedral_solid.polyhedron_vertex( { 0, 2 } ) == 2,
@@ -545,7 +545,7 @@ void test_delete_all( const geode::PolyhedralSolid3D& polyhedral_solid,
     builder.delete_polyhedra( to_delete );
     OPENGEODE_EXCEPTION( polyhedral_solid.nb_vertices() == 7,
         "[Test] PolyhedralSolid should have 7 vertices" );
-    OPENGEODE_EXCEPTION( polyhedral_solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( polyhedral_solid.is_vertex_isolated( 0 ),
         "[Test] Vertices should be isolated after polyhedra deletion" );
     OPENGEODE_EXCEPTION( polyhedral_solid.nb_polyhedra() == 0,
         "[Test] PolyhedralSolid should have 0 polyhedron" );

--- a/tests/mesh/test-tetrahedral-solid-view.cpp
+++ b/tests/mesh/test-tetrahedral-solid-view.cpp
@@ -94,10 +94,10 @@ void test_create_viewed_tetrahedra( const geode::TetrahedralSolidView3D& solid,
 void test_isolated( const geode::TetrahedralSolid3D& solid,
     geode::TetrahedralSolidViewBuilder3D& builder )
 {
-    OPENGEODE_EXCEPTION( !solid.isolated_vertex( 0 ),
+    OPENGEODE_EXCEPTION( !solid.is_vertex_isolated( 0 ),
         "[Test] TetrahedralSolidView isolated vertex is not correct" );
     builder.add_viewed_vertex( 0 );
-    OPENGEODE_EXCEPTION( solid.isolated_vertex( 5 ),
+    OPENGEODE_EXCEPTION( solid.is_vertex_isolated( 5 ),
         "[Test] TetrahedralSolidView isolated vertex is not correct" );
 }
 

--- a/upgrade-guide.md
+++ b/upgrade-guide.md
@@ -8,6 +8,7 @@ TODO
 
 ### Breaking Changes
 
+- **Mesh**: The mesh `isolated_XXX` (e.g. `isolated_vertex`) has been renamed `is_XXX_isolated`.
 
 ## Upgrading from OpenGeode v8.x.x to v9.0.0
 


### PR DESCRIPTION
BREAKING CHANGE: isolated_XXX methods renamed in is_XXX_isolated

fix #383 