### PR TITLE
perf(SolidMesh): better return type of polyhedron_facets_vertices and polyhedron_edges_vertices

### DIFF
--- a/include/geode/mesh/core/geode_hybrid_solid.h
+++ b/include/geode/mesh/core/geode_hybrid_solid.h
@@ -138,10 +138,10 @@ namespace geode
         absl::optional< index_t > get_polyhedron_adjacent(
             const PolyhedronFacet& polyhedron_facet ) const override;
 
-        std::vector< std::array< index_t, 2 > > polyhedron_edges_vertices(
+        PolyhedronEdgesVertices polyhedron_edges_vertices(
             index_t polyhedron ) const final;
 
-        std::vector< PolyhedronFacetVertices > polyhedron_facets_vertices(
+        PolyhedronFacetsVertices polyhedron_facets_vertices(
             index_t polyhedron ) const final;
 
         typename HybridSolid< dimension >::Type polyhedron_type(

--- a/include/geode/mesh/core/solid_mesh.h
+++ b/include/geode/mesh/core/solid_mesh.h
@@ -197,7 +197,13 @@ namespace geode
         local_index_t edge_id{ NO_LID };
     };
 
+    using PolyhedronEdgesVertices =
+        absl::InlinedVector< std::array< index_t, 2 >, 6 >;
+
     using PolyhedronFacetVertices = absl::InlinedVector< index_t, 3 >;
+
+    using PolyhedronFacetsVertices =
+        absl::InlinedVector< PolyhedronFacetVertices, 4 >;
 
     using PolyhedronVertices = absl::InlinedVector< index_t, 4 >;
 
@@ -314,8 +320,8 @@ namespace geode
                 const std::array< index_t, 2 >& edge_vertices,
                 index_t polyhedron_id ) const;
 
-        virtual std::vector< std::array< index_t, 2 > >
-            polyhedron_edges_vertices( index_t polyhedron ) const;
+        virtual PolyhedronEdgesVertices polyhedron_edges_vertices(
+            index_t polyhedron ) const;
 
         absl::optional< PolyhedronFacet > polyhedron_facet_from_vertices(
             PolyhedronFacetVertices polyhedron_facet_vertices ) const;
@@ -323,8 +329,8 @@ namespace geode
         PolyhedronFacetVertices polyhedron_facet_vertices(
             const PolyhedronFacet& polyhedron_facet ) const;
 
-        virtual std::vector< PolyhedronFacetVertices >
-            polyhedron_facets_vertices( index_t polyhedron ) const;
+        virtual PolyhedronFacetsVertices polyhedron_facets_vertices(
+            index_t polyhedron ) const;
 
         virtual PolyhedronFacets polyhedron_vertex_facets(
             const PolyhedronVertex& polyhedron_vertex ) const;

--- a/include/geode/mesh/core/tetrahedral_solid.h
+++ b/include/geode/mesh/core/tetrahedral_solid.h
@@ -63,10 +63,10 @@ namespace geode
 
         std::unique_ptr< TetrahedralSolid< dimension > > clone() const;
 
-        std::vector< std::array< index_t, 2 > > polyhedron_edges_vertices(
+        PolyhedronEdgesVertices polyhedron_edges_vertices(
             index_t polyhedron ) const final;
 
-        std::vector< PolyhedronFacetVertices > polyhedron_facets_vertices(
+        PolyhedronFacetsVertices polyhedron_facets_vertices(
             index_t polyhedron ) const final;
 
         PolyhedraAroundEdge polyhedra_around_edge(

--- a/src/geode/mesh/core/geode_hybrid_solid.cpp
+++ b/src/geode/mesh/core/geode_hybrid_solid.cpp
@@ -51,12 +51,12 @@ namespace
     };
 
     template < typename Data >
-    std::vector< std::array< geode::index_t, 2 > > polyhedron_edges_vertices(
+    geode::PolyhedronEdgesVertices polyhedron_edges_vertices(
         const geode::HybridSolid3D& mesh,
         geode::index_t polyhedron,
         const Data& data )
     {
-        std::vector< std::array< geode::index_t, 2 > > result;
+        geode::PolyhedronEdgesVertices result;
         result.reserve( data.size() );
         for( const auto& edge : data )
         {
@@ -68,12 +68,12 @@ namespace
     }
 
     template < typename Data >
-    std::vector< geode::PolyhedronFacetVertices > polyhedron_facets_vertices(
+    geode::PolyhedronFacetsVertices polyhedron_facets_vertices(
         const geode::HybridSolid3D& mesh,
         geode::index_t polyhedron,
         const Data& data )
     {
-        std::vector< geode::PolyhedronFacetVertices > result;
+        geode::PolyhedronFacetsVertices result;
         result.reserve( data.size() );
         for( const auto& facet : data )
         {
@@ -293,7 +293,7 @@ namespace geode
                 polyhedron_adjacents_.end() );
         }
 
-        std::vector< std::array< index_t, 2 > > polyhedron_edges_vertices(
+        PolyhedronEdgesVertices polyhedron_edges_vertices(
             const HybridSolid< dimension >& solid, index_t polyhedron ) const
         {
             switch( polyhedron_type( polyhedron ) )
@@ -317,7 +317,7 @@ namespace geode
             return {};
         }
 
-        std::vector< PolyhedronFacetVertices > polyhedron_facets_vertices(
+        PolyhedronFacetsVertices polyhedron_facets_vertices(
             const HybridSolid< dimension >& solid, index_t polyhedron ) const
         {
             switch( polyhedron_type( polyhedron ) )
@@ -604,7 +604,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    std::vector< std::array< index_t, 2 > >
+    PolyhedronEdgesVertices
         OpenGeodeHybridSolid< dimension >::polyhedron_edges_vertices(
             index_t polyhedron ) const
     {
@@ -612,7 +612,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    std::vector< PolyhedronFacetVertices >
+    PolyhedronFacetsVertices
         OpenGeodeHybridSolid< dimension >::polyhedron_facets_vertices(
             index_t polyhedron ) const
     {

--- a/src/geode/mesh/core/tetrahedral_solid.cpp
+++ b/src/geode/mesh/core/tetrahedral_solid.cpp
@@ -227,23 +227,25 @@ namespace geode
         index_t first_polyhedron ) const
     {
         PolyhedraAroundEdge result{ first_polyhedron };
-        const auto v0 =
-            this->vertex_in_polyhedron( first_polyhedron, vertices[0] );
-        OPENGEODE_ASSERT( v0, "[TetrahedralSolid::polyhedra_around_edge] First "
-                              "vertex is not in given tetrahedron" );
-        const auto v1 =
-            this->vertex_in_polyhedron( first_polyhedron, vertices[1] );
-        OPENGEODE_ASSERT( v1,
-            "[TetrahedralSolid::polyhedra_around_edge] Second "
-            "vertex is not in given tetrahedron" );
+        std::array< index_t, 2 > excluded_facets{ NO_ID, NO_ID };
+        local_index_t count{ 0 };
+        const auto polyhedron_vertices =
+            this->polyhedron_vertices( first_polyhedron );
+        for( const auto v : LRange{ 4 } )
+        {
+            if( polyhedron_vertices[v] == vertices[0]
+                || polyhedron_vertices[v] == vertices[1] )
+            {
+                excluded_facets[count++] = v;
+            }
+        }
         for( const auto f : LRange{ 4 } )
         {
-            if( f == v0 || f == v1 )
+            if( f == excluded_facets[0] || f == excluded_facets[1] )
             {
                 continue;
             }
-            const auto vertex_id =
-                this->polyhedron_vertex( { first_polyhedron, f } );
+            const auto vertex_id = polyhedron_vertices[f];
             if( vertex_id == vertices[0] || vertex_id == vertices[1] )
             {
                 continue;
@@ -273,7 +275,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    std::vector< std::array< index_t, 2 > >
+    PolyhedronEdgesVertices
         TetrahedralSolid< dimension >::polyhedron_edges_vertices(
             index_t polyhedron ) const
     {
@@ -282,8 +284,7 @@ namespace geode
             this->polyhedron_vertex( { polyhedron, 1 } ),
             this->polyhedron_vertex( { polyhedron, 2 } ),
             this->polyhedron_vertex( { polyhedron, 3 } ) };
-        std::vector< std::array< index_t, 2 > > result;
-        result.reserve( detail::tetrahedron_edge_vertices.size() );
+        PolyhedronEdgesVertices result;
         for( const auto& edge : detail::tetrahedron_edge_vertices )
         {
             result.emplace_back( std::array< index_t, 2 >{
@@ -306,7 +307,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    std::vector< PolyhedronFacetVertices >
+    PolyhedronFacetsVertices
         TetrahedralSolid< dimension >::polyhedron_facets_vertices(
             index_t polyhedron ) const
     {
@@ -315,8 +316,7 @@ namespace geode
             this->polyhedron_vertex( { polyhedron, 1 } ),
             this->polyhedron_vertex( { polyhedron, 2 } ),
             this->polyhedron_vertex( { polyhedron, 3 } ) };
-        std::vector< PolyhedronFacetVertices > result;
-        result.reserve( detail::tetrahedron_facet_vertices.size() );
+        PolyhedronFacetsVertices result;
         for( const auto& facet : detail::tetrahedron_facet_vertices )
         {
             result.emplace_back( PolyhedronFacetVertices{


### PR DESCRIPTION
WARNING: there is a minor breaking change due to the return type modification. Please prefer using auto or absl::Span for better generic code