### PR TITLE
fix(CMake): provide target with less tests

### DIFF
--- a/cmake/ConfigureOpenGeode.cmake
+++ b/cmake/ConfigureOpenGeode.cmake
@@ -63,3 +63,14 @@ ExternalProject_Add(opengeode
         ${bindings}
 )
 
+add_custom_target(third_party
+    DEPENDS
+        abseil
+        asyncplusplus
+        bitsery
+        ghcFilesystem
+        minizip
+        nanoflann
+        spdlog
+        ${bindings}
+)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -123,6 +123,9 @@ if(DOXYGEN_FOUND AND EXISTS ${PROJECT_SOURCE_DIR}/cmake/Doxyfile.in)
         VERBATIM )
 endif()
 
+add_custom_target(third_party)
+add_custom_target(essential)
+
 function(_export_library library_name)
     export(TARGETS ${library_name}
         NAMESPACE ${PROJECT_NAME}::
@@ -188,6 +191,7 @@ function(add_geode_library)
         )
     endif()
     add_library(${PROJECT_NAME}::${GEODE_LIB_NAME} ALIAS ${GEODE_LIB_NAME})
+    add_dependencies(essential ${GEODE_LIB_NAME})
     string(TOLOWER ${PROJECT_NAME} project-name)
     string(REGEX REPLACE "-" "_" project_name ${project-name})
     set_target_properties(${GEODE_LIB_NAME}
@@ -330,13 +334,16 @@ endfunction()
 option(USE_BENCHMARK "Toggle benchmarking of tests" OFF)
 function(add_geode_test)
     cmake_parse_arguments(GEODE_TEST
-        ""
+        "ESSENTIAL"
         "SOURCE"
         "DEPENDENCIES"
         ${ARGN}
     )
     _add_geode_executable(${GEODE_TEST_SOURCE} "Tests" ${GEODE_TEST_DEPENDENCIES})
     add_test(NAME ${target_name} COMMAND ${target_name})
+    if(${GEODE_TEST_ESSENTIAL})
+        add_dependencies(essential ${target_name})
+    endif()
     set_tests_properties(${target_name} PROPERTIES TIMEOUT 300) 
     _add_dependency_directories(${target_name} ${GEODE_TEST_DEPENDENCIES})
     if(USE_BENCHMARK)

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -33,6 +33,7 @@ add_geode_test(
     SOURCE "test-attribute.cpp"
     DEPENDENCIES
         ${PROJECT_NAME}::basic
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-cached-value.cpp"
@@ -88,4 +89,5 @@ add_geode_test(
     SOURCE "test-uuid.cpp"
     DEPENDENCIES
         ${PROJECT_NAME}::basic
+    ESSENTIAL
 )

--- a/tests/geometry/CMakeLists.txt
+++ b/tests/geometry/CMakeLists.txt
@@ -59,12 +59,14 @@ add_geode_test(
     DEPENDENCIES
         ${PROJECT_NAME}::basic
         ${PROJECT_NAME}::geometry
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-intersection-detection.cpp"
     DEPENDENCIES
         ${PROJECT_NAME}::basic
         ${PROJECT_NAME}::geometry
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-mensuration.cpp"

--- a/tests/mesh/CMakeLists.txt
+++ b/tests/mesh/CMakeLists.txt
@@ -106,6 +106,7 @@ add_geode_test(
         ${PROJECT_NAME}::basic
         ${PROJECT_NAME}::geometry
         ${PROJECT_NAME}::mesh
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-mesh-factory.cpp"
@@ -133,6 +134,7 @@ add_geode_test(
         ${PROJECT_NAME}::basic
         ${PROJECT_NAME}::geometry
         ${PROJECT_NAME}::mesh
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-polyhedral-solid.cpp"
@@ -146,6 +148,7 @@ add_geode_test(
     DEPENDENCIES
         ${PROJECT_NAME}::basic
         ${PROJECT_NAME}::mesh
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-ray-tracing.cpp"

--- a/tests/model/CMakeLists.txt
+++ b/tests/model/CMakeLists.txt
@@ -24,6 +24,7 @@ add_geode_test(
         ${PROJECT_NAME}::basic
         ${PROJECT_NAME}::geometry
         ${PROJECT_NAME}::model
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-component-mesh-edges.cpp"
@@ -57,6 +58,7 @@ add_geode_test(
         ${PROJECT_NAME}::basic
         ${PROJECT_NAME}::geometry
         ${PROJECT_NAME}::model
+    ESSENTIAL
 )
 add_geode_test(
     SOURCE "test-model-component-filter.cpp"


### PR DESCRIPTION
To use it, I will change the actions to:
```
cd build
make third_party
cd opengeode
make light
make test
```

What tests are we enabling?