### PR TITLE
fix(Attribute): use default value in VariableAttribute copy method to…

### DIFF
--- a/include/geode/basic/attribute.h
+++ b/include/geode/basic/attribute.h
@@ -492,7 +492,7 @@ namespace geode
             default_value_ = typed_attribute.default_value_;
             if( nb_elements != 0 )
             {
-                values_.resize( nb_elements );
+                values_.resize( nb_elements, default_value_ );
                 for( const auto i : Range{ nb_elements } )
                 {
                     values_[i] = typed_attribute.value( i );


### PR DESCRIPTION
… allow its use with no default constructor type