### PR TITLE
Allow silent invocation of repair_polygon_orientations(..)

### DIFF
--- a/src/geode/mesh/helpers/repair_polygon_orientations.cpp
+++ b/src/geode/mesh/helpers/repair_polygon_orientations.cpp
@@ -329,7 +329,7 @@ namespace geode
         {
             builder.edges_builder().delete_isolated_edges();
         }
-        Logger::info( "Repair polygons orientations: ",
+        Logger::debug( "Repair polygons orientations: ",
             polygons_to_reorient.size(), " polygons reoriented" );
     }
 


### PR DESCRIPTION
To avoid polluting the log when `repair_polygon_orientations(..)` is invoked frequently.