### PR TITLE
fix(IO): enable export of 8bit-valued attributes to Paraview

### DIFF
--- a/include/geode/basic/attribute_utils.h
+++ b/include/geode/basic/attribute_utils.h
@@ -25,6 +25,7 @@
 
 #include <geode/basic/bitsery_archive.h>
 #include <geode/basic/common.h>
+#include <geode/basic/types.h>
 
 namespace geode
 {
@@ -202,6 +203,7 @@ namespace geode
     IMPLICIT_GENERIC_ATTRIBUTE_CONVERSION( unsigned int );
     IMPLICIT_GENERIC_ATTRIBUTE_CONVERSION( float );
     IMPLICIT_GENERIC_ATTRIBUTE_CONVERSION( double );
+    IMPLICIT_GENERIC_ATTRIBUTE_CONVERSION( local_index_t );
 
 #define IMPLICIT_ARRAY_GENERIC_ATTRIBUTE_CONVERSION( Type )                    \
     template < size_t size >                                                   \


### PR DESCRIPTION
Hi,

The use-case is to be able to export a `geode::EdgedCurve3D` mesh with its attributes -- one of them being valued as 8-bit integers (aka. `geode::local_index_t`) -- to Paraview (through the .vtp file format).

Currently, 8-bit-valued attributes are not exported in Paraview .vtp files. From what I understand in the code in OpenGeodeIO, this is because these attributes are not flaggued as "genericable". The PR fixes that, but it modifies the core lib, and I'm not able to assess all the possible impacts...