### PR TITLE
fix(CMake): wrong RPATH for executables after install

### DIFF
--- a/cmake/CppTargets.cmake
+++ b/cmake/CppTargets.cmake
@@ -200,7 +200,7 @@ function(_add_geode_executable exe_path folder_name)
     set_target_properties(${target_name}
         PROPERTIES
             FOLDER ${folder_name}
-            INSTALL_RPATH "${OS_RPATH}/../${CMAKE_INSTALL_LIBDIR}"
+            INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
     )
     set(target_name ${target_name} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
When creating an executable with `add_geode_binary`, if this executable links a lib created in the same CMake project AND is configured to be installed to a custom directory, it does not work after install.

Example with the attached reproducer:
```
cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/install/dir -DCMAKE_PREFIX_PATH=/path/to/geode
make
./bin/reproducer    # OK
make install
/path/to/install/dir/bin/reproducer    # error while loading shared libraries...
```

Checking the RUNPATH header in the binaries explains this behavior:
```
objdump -x ./bin/reproducer | grep RUNPATH
# RUNPATH    $ORIGIN/../lib:
objdump -x /path/to/install/dir/bin/reproducer | grep RUNPATH
# RUNPATH    /../lib
```
-> the 2nd RUNPATH is invalid.
