### PR TITLE
feat(SolidMesh): add polyhedron_facet_area

### DIFF
--- a/include/geode/mesh/core/solid_mesh.h
+++ b/include/geode/mesh/core/solid_mesh.h
@@ -426,6 +426,13 @@ namespace geode
             const PolyhedronFacet& polyhedron_facet ) const;
 
         /*!
+         * Return the area of a given PolyhedronFacet.
+         * @param[in] polyhedron_facet Local index of facet in polyhedron.
+         */
+        double polyhedron_facet_area(
+            const PolyhedronFacet& polyhedron_facet ) const;
+
+        /*!
          * Return the normal of a given PolyhedronFacet.
          * @param[in] polyhedron_facet Local index of facet in polyhedron.
          */

--- a/src/geode/mesh/core/solid_mesh.cpp
+++ b/src/geode/mesh/core/solid_mesh.cpp
@@ -810,7 +810,7 @@ namespace geode
         }
         double area{ 0 };
         const auto direction = new_polyhedron_facet_normal( polyhedron_facet )
-            .value_or( Vector3D{ { 0, 0, 1 } } );
+                                   .value_or( Vector3D{ { 0, 0, 1 } } );
         const auto vertices = polyhedron_facet_vertices( polyhedron_facet );
         const auto& p1 = this->point( vertices[0] );
         for( const auto i : LRange{ 1, vertices.size() - 1 } )

--- a/src/geode/mesh/core/solid_mesh.cpp
+++ b/src/geode/mesh/core/solid_mesh.cpp
@@ -801,6 +801,28 @@ namespace geode
     }
 
     template < index_t dimension >
+    double SolidMesh< dimension >::polyhedron_facet_area(
+        const PolyhedronFacet& polyhedron_facet ) const
+    {
+        if( nb_polyhedron_facet_vertices( polyhedron_facet ) < 3 )
+        {
+            return 0;
+        }
+        double area{ 0 };
+        const auto direction = new_polyhedron_facet_normal( polyhedron_facet )
+            .value_or( Vector3D{ { 0, 0, 1 } } );
+        const auto vertices = polyhedron_facet_vertices( polyhedron_facet );
+        const auto& p1 = this->point( vertices[0] );
+        for( const auto i : LRange{ 1, vertices.size() - 1 } )
+        {
+            const auto& p2 = this->point( vertices[i] );
+            const auto& p3 = this->point( vertices[i + 1] );
+            area += triangle_signed_area( { p1, p2, p3 }, direction );
+        }
+        return area;
+    }
+
+    template < index_t dimension >
     Vector3D SolidMesh< dimension >::polyhedron_facet_normal(
         const PolyhedronFacet& polyhedron_facet ) const
     {

--- a/tests/mesh/test-tetrahedral-solid.cpp
+++ b/tests/mesh/test-tetrahedral-solid.cpp
@@ -87,7 +87,7 @@ void test_polyhedron_facet_area( const geode::TetrahedralSolid3D& solid )
 {
     for( const auto p : geode::Range{ solid.nb_polyhedra() } )
     {
-        for( const auto f : geode::LRange{ solid.nb_polyhedron_facets(p) } )
+        for( const auto f : geode::LRange{ solid.nb_polyhedron_facets( p ) } )
         {
             auto actual = std::fabs( solid.polyhedron_facet_area( { p, f } ) );
             auto expected = geode::triangle_area( solid.triangle( { p, f } ) );

--- a/tests/mesh/test-tetrahedral-solid.cpp
+++ b/tests/mesh/test-tetrahedral-solid.cpp
@@ -25,6 +25,7 @@
 #include <geode/basic/logger.h>
 
 #include <geode/geometry/basic_objects/tetrahedron.h>
+#include <geode/geometry/basic_objects/triangle.h>
 #include <geode/geometry/mensuration.h>
 #include <geode/geometry/point.h>
 
@@ -79,6 +80,21 @@ void test_polyhedron_volumes( const geode::TetrahedralSolid3D& solid )
                                             solid.tetrahedron( p ) ) )
                                  < geode::global_epsilon,
             "[Test] Not correct tetrahedron volume computation" );
+    }
+}
+
+void test_polyhedron_facet_area( const geode::TetrahedralSolid3D& solid )
+{
+    for( const auto p : geode::Range{ solid.nb_polyhedra() } )
+    {
+        for( const auto f : geode::LRange{ solid.nb_polyhedron_facets(p) } )
+        {
+            auto actual = std::fabs( solid.polyhedron_facet_area( { p, f } ) );
+            auto expected = geode::triangle_area( solid.triangle( { p, f } ) );
+            OPENGEODE_EXCEPTION(
+                std::fabs( actual - expected ) < geode::global_epsilon,
+                "[Test] Not correct tetrahedron facet area computation" );
+        }
     }
 }
 
@@ -369,6 +385,7 @@ void test()
     test_create_vertices( *solid, *builder );
     test_create_tetrahedra( *solid, *builder );
     test_polyhedron_volumes( *solid );
+    test_polyhedron_facet_area( *solid );
     test_polyhedron_adjacencies( *solid, *builder );
     test_is_on_border( *solid );
     test_io( *solid, absl::StrCat( "test.", solid->native_extension() ) );


### PR DESCRIPTION
Added a method on SolidMesh to compute the area of a polyhedron facet. Implementation similar to SurfaceMesh3D::polygon_area.