### PR TITLE
feat(ProgressLogger): allow to change the refresh interval

### DIFF
--- a/include/geode/basic/progress_logger.hpp
+++ b/include/geode/basic/progress_logger.hpp
@@ -25,6 +25,8 @@
 
 #include <string>
 
+#include <absl/time/clock.h>
+
 #include <geode/basic/common.hpp>
 #include <geode/basic/pimpl.hpp>
 
@@ -33,7 +35,9 @@ namespace geode
     class opengeode_basic_api ProgressLogger
     {
     public:
-        ProgressLogger( const std::string& message, index_t nb_steps );
+        ProgressLogger( const std::string& message,
+            index_t nb_steps,
+            absl::Duration refresh_interval = absl::Seconds( 1 ) );
         ~ProgressLogger();
 
         index_t increment();


### PR DESCRIPTION
The default 1 sec interval may result in verbose logs in case of long jobs.