### PR TITLE
feat(Timer): provide access to duration in raw format

### DIFF
--- a/include/geode/basic/timer.hpp
+++ b/include/geode/basic/timer.hpp
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <absl/time/time.h>
+
 #include <geode/basic/common.hpp>
 #include <geode/basic/pimpl.hpp>
 
@@ -34,6 +36,8 @@ namespace geode
         Timer();
         Timer( Timer&& other ) noexcept;
         ~Timer();
+
+        absl::Duration raw_duration() const;
 
         std::string duration() const;
 

--- a/src/geode/basic/timer.cpp
+++ b/src/geode/basic/timer.cpp
@@ -37,9 +37,14 @@ namespace geode
             reset();
         }
 
+        absl::Duration raw_duration() const
+        {
+            return absl::Now() - start_time_;
+        }
+
         std::string duration() const
         {
-            return absl::FormatDuration( absl::Now() - start_time_ );
+            return absl::FormatDuration( raw_duration() );
         }
 
         void reset()
@@ -56,6 +61,11 @@ namespace geode
     Timer::Timer( Timer&& ) noexcept = default;
 
     Timer::~Timer() = default;
+
+    absl::Duration Timer::raw_duration() const
+    {
+        return impl_->raw_duration();
+    }
 
     std::string Timer::duration() const
     {


### PR DESCRIPTION
Having access to timer duration as `absl::Duration` (instead of just as a human-readable string) is necessary to be able to perform arithmetic operations (e.g. adding timer durations, computing min/max/average durations over several runs, etc.).