### PR TITLE
fix(Return): remove [[nodiscard]] specifier on find_or_create_attribute(..)

### DIFF
--- a/include/geode/basic/attribute_manager.hpp
+++ b/include/geode/basic/attribute_manager.hpp
@@ -103,10 +103,10 @@ namespace geode
          * @exception OpenGeodeException if the Attribute replacement failed
          */
         template < template < typename > class Attribute, typename T >
-        [[nodiscard]] std::shared_ptr< Attribute< T > >
-            find_or_create_attribute( std::string_view name,
-                T default_value,
-                AttributeProperties properties )
+        std::shared_ptr< Attribute< T > > find_or_create_attribute(
+            std::string_view name,
+            T default_value,
+            AttributeProperties properties )
         {
             auto attribute = find_attribute_base( name );
             auto typed_attribute =
@@ -127,8 +127,8 @@ namespace geode
         }
 
         template < template < typename > class Attribute, typename T >
-        [[nodiscard]] std::shared_ptr< Attribute< T > >
-            find_or_create_attribute( std::string_view name, T default_value )
+        std::shared_ptr< Attribute< T > > find_or_create_attribute(
+            std::string_view name, T default_value )
         {
             return find_or_create_attribute< Attribute, T >(
                 name, std::move( default_value ), AttributeProperties{} );


### PR DESCRIPTION
It may be relevant to ignore the pointer returned by `find_or_create_attribute(..)` if the caller just wants to create the attribute (or to ensure it exists).