### PR TITLE
fix(CMake): let CMAKE_UNITY_BUILD manage unity build if present

### DIFF
--- a/cmake/CppTargets.cmake
+++ b/cmake/CppTargets.cmake
@@ -109,8 +109,17 @@ function(add_geode_library)
             OUTPUT_NAME ${PROJECT_NAME}_${GEODE_LIB_NAME}
             DEFINE_SYMBOL ${project_name}_${GEODE_LIB_NAME}_EXPORTS
             FOLDER "Libraries"
-            UNITY_BUILD ON
     )
+
+    # Enable unity build by default, unless another behavior is
+    # explicitly defined through CMAKE_UNITY_BUILD.
+    if(NOT DEFINED CMAKE_UNITY_BUILD)
+        set_target_properties(${GEODE_LIB_NAME}
+            PROPERTIES
+                UNITY_BUILD ON
+        )
+    endif()
+
     target_compile_options(${GEODE_LIB_NAME} 
         PRIVATE ${COMPILER_WARNINGS}
     )


### PR DESCRIPTION
Let global variable [CMAKE_UNITY_BUILD](https://cmake.org/cmake/help/latest/variable/CMAKE_UNITY_BUILD.html) controls whether unity build should be enabled or not if this variable is set.

Examples of use-cases for which disabling unity build is useful:
- in CI workflows, to detect issues that may be hidden by the unity build (typically: poorly-managed includes, template implentation in .cpp files, etc.)
- to improve integration with VSCode and other IDEs relying on [`compile_commands.json`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) (see https://gitlab.kitware.com/cmake/cmake/-/work_items/19826)