### PR TITLE
feat(Attributes): add no-value property support

### DIFF
--- a/bindings/python/src/basic/attribute.cpp
+++ b/bindings/python/src/basic/attribute.cpp
@@ -53,23 +53,47 @@ namespace geode
             std::shared_ptr< VariableAttribute< type > > >(
             module, variable_name.c_str() )
             .def( "set_value", &VariableAttribute< type >::set_value )
-            .def( "default_value", &VariableAttribute< type >::default_value );
+            .def(
+                "default_values", &VariableAttribute< type >::default_values );
         const auto sparse_name = absl::StrCat( "SparseAttribute", typestr );
         pybind11::class_< SparseAttribute< type >, ReadOnlyAttribute< type >,
             std::shared_ptr< SparseAttribute< type > > >(
             module, sparse_name.c_str() )
             .def( "set_value", &SparseAttribute< type >::set_value )
-            .def( "default_value", &SparseAttribute< type >::default_value );
+            .def( "default_values", &SparseAttribute< type >::default_values );
+    }
+
+    template < typename type >
+    void python_attribute_values_class(
+        pybind11::module& module, const std::string& typestr )
+    {
+        const auto values_name = absl::StrCat( "AttributeValues", typestr );
+        pybind11::class_< AttributeValues< type > >(
+            module, values_name.c_str() )
+            .def( pybind11::init<>() )
+            .def_readwrite(
+                "default_value", &AttributeValues< type >::default_value )
+            .def_readwrite( "no_value", &AttributeValues< type >::no_value );
     }
 
     void define_attributes( pybind11::module& module )
     {
         pybind11::class_< AttributeProperties >( module, "AttributeProperties" )
             .def( pybind11::init<>() )
-            .def( pybind11::init< bool, bool >() )
             .def_readwrite( "assignable", &AttributeProperties::assignable )
+            .def_readwrite( "interpolable", &AttributeProperties::interpolable )
             .def_readwrite(
-                "interpolable", &AttributeProperties::interpolable );
+                "transferable", &AttributeProperties::transferable );
+
+        python_attribute_values_class< bool >( module, "Bool" );
+        python_attribute_values_class< int >( module, "Int" );
+        python_attribute_values_class< unsigned int >( module, "UInt" );
+        python_attribute_values_class< float >( module, "Float" );
+        python_attribute_values_class< double >( module, "Double" );
+        python_attribute_values_class< std::array< double, 2 > >(
+            module, "ArrayDouble2" );
+        python_attribute_values_class< std::array< double, 3 > >(
+            module, "ArrayDouble3" );
 
         pybind11::class_< AttributeBase, std::shared_ptr< AttributeBase > >(
             module, "AttributeBase" )

--- a/bindings/python/src/basic/attribute_manager.cpp
+++ b/bindings/python/src/basic/attribute_manager.cpp
@@ -43,13 +43,13 @@ namespace geode
         const auto create_constant_suffix =
             absl::StrCat( "create_attribute_constant_", suffix );
         manager.def( create_constant_suffix.c_str(),
-            static_cast< geode::uuid ( AttributeManager::* )(
-                std::string_view, type, AttributeProperties ) >(
+            static_cast< geode::uuid ( AttributeManager::* )( std::string_view,
+                AttributeValues< type >, AttributeProperties ) >(
                 &AttributeManager::create_attribute< ConstantAttribute,
                     type > ) );
         manager.def( create_constant_suffix.c_str(),
-            static_cast< void ( AttributeManager::* )(
-                std::string_view, const uuid&, type, AttributeProperties ) >(
+            static_cast< void ( AttributeManager::* )( std::string_view,
+                const uuid&, AttributeValues< type >, AttributeProperties ) >(
                 &AttributeManager::create_attribute< ConstantAttribute,
                     type > ) );
         const auto find_constant_suffix =
@@ -62,13 +62,13 @@ namespace geode
         const auto create_variable_suffix =
             absl::StrCat( "create_attribute_variable_", suffix );
         manager.def( create_variable_suffix.c_str(),
-            static_cast< geode::uuid ( AttributeManager::* )(
-                std::string_view, type, AttributeProperties ) >(
+            static_cast< geode::uuid ( AttributeManager::* )( std::string_view,
+                AttributeValues< type >, AttributeProperties ) >(
                 &AttributeManager::create_attribute< VariableAttribute,
                     type > ) );
         manager.def( create_variable_suffix.c_str(),
-            static_cast< void ( AttributeManager::* )(
-                std::string_view, const uuid&, type, AttributeProperties ) >(
+            static_cast< void ( AttributeManager::* )( std::string_view,
+                const uuid&, AttributeValues< type >, AttributeProperties ) >(
                 &AttributeManager::create_attribute< VariableAttribute,
                     type > ) );
         const auto find_variable_suffix =
@@ -81,13 +81,13 @@ namespace geode
         const auto create_sparse_suffix =
             absl::StrCat( "create_attribute_sparse_", suffix );
         manager.def( create_sparse_suffix.c_str(),
-            static_cast< geode::uuid ( AttributeManager::* )(
-                std::string_view, type, AttributeProperties ) >(
+            static_cast< geode::uuid ( AttributeManager::* )( std::string_view,
+                AttributeValues< type >, AttributeProperties ) >(
                 &AttributeManager::create_attribute< SparseAttribute,
                     type > ) );
         manager.def( create_sparse_suffix.c_str(),
-            static_cast< void ( AttributeManager::* )(
-                std::string_view, const uuid&, type, AttributeProperties ) >(
+            static_cast< void ( AttributeManager::* )( std::string_view,
+                const uuid&, AttributeValues< type >, AttributeProperties ) >(
                 &AttributeManager::create_attribute< SparseAttribute,
                     type > ) );
         const auto find_sparse_suffix =

--- a/bindings/python/tests/basic/test-py-attribute.py
+++ b/bindings/python/tests/basic/test-py-attribute.py
@@ -31,8 +31,15 @@ import opengeode_py_basic as basic
 
 def test_constant_attribute(manager):
     
+    properties = basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = basic.AttributeValuesBool()
+    values.default_value = True
+    values.no_value = False
     constant_attribute_id = manager.create_attribute_constant_bool(
-        "bool", True, basic.AttributeProperties())
+        "bool", values, properties)
     constant_attribute = manager.find_attribute_constant_bool(constant_attribute_id)
     attribute = manager.find_read_only_attribute_bool(constant_attribute_id)
     if not attribute.value(0):
@@ -45,14 +52,27 @@ def test_constant_attribute(manager):
 
 
 def test_int_variable_attribute(manager):
+
+    properties = basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = basic.AttributeValuesInt()
+    values.default_value = 12
+    values.no_value = 12
     variable_attribute_id = manager.create_attribute_variable_int(
-        "int", 12,basic.AttributeProperties())
+        "int", values, properties)
     variable_attribute = manager.find_attribute_variable_int(variable_attribute_id)
     variable_attribute.set_value(3, 3)
     if not variable_attribute.is_genericable():
         raise ValueError("[Test] Should be genericable")
+
+    new_properties = basic.AttributeProperties()
+    new_properties.assignable = True
+    new_properties.interpolable = True
+    properties.transferable = True
+    manager.set_attribute_properties(variable_attribute_id,new_properties)
     
-    manager.set_attribute_properties(variable_attribute_id,basic.AttributeProperties(True,True))
     if not variable_attribute.properties().assignable or not variable_attribute.properties().interpolable :
         raise ValueError("[Test] Should be assignable and interpolable")
 
@@ -74,8 +94,16 @@ def test_int_variable_attribute(manager):
 
 
 def test_double_sparse_attribute(manager):
+
+    properties = basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = basic.AttributeValuesDouble()
+    values.default_value = 12
+    values.no_value = 12
     sparse_attribute_id = manager.create_attribute_sparse_double(
-        "double", 12,basic.AttributeProperties())
+        "double", values,properties)
     attribute = manager.find_attribute_sparse_double(sparse_attribute_id)
     attribute.set_value(3, 3)
     attribute.set_value(7, 7)

--- a/bindings/python/tests/mesh/test-py-edged-curve.py
+++ b/bindings/python/tests/mesh/test-py-edged-curve.py
@@ -123,8 +123,16 @@ def test_edge_requests(edged_curve, builder):
 
 
 def test_clone(edged_curve):
+
+    properties = opengeode_py_basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = opengeode_py_basic.AttributeValuesInt()
+    values.default_value = 0
+    values.no_value = 0
     attribute_id = edged_curve.edge_attribute_manager(
-    ).create_attribute_variable_int("test", 0,opengeode_py_basic.AttributeProperties())
+    ).create_attribute_variable_int("test", values,properties)
 
     attribute = edged_curve.edge_attribute_manager().find_attribute_variable_int(attribute_id)
     attribute.set_value(0, 42)

--- a/bindings/python/tests/mesh/test-py-gradient-computation.py
+++ b/bindings/python/tests/mesh/test-py-gradient-computation.py
@@ -35,7 +35,14 @@ def test_gradient_grid2D():
     builder = mesh.RegularGridBuilder2D.create( grid )
     builder.initialize_cartesian_grid( geom.Point2D([ 0, 0 ] ), [ 3, 3 ], 1 )
     scalar_function_name = "scalar_function"
-    attribute_id = grid.vertex_attribute_manager().create_attribute_variable_double( scalar_function_name, 0,opengeode_py_basic.AttributeProperties() )
+    properties = opengeode_py_basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = opengeode_py_basic.AttributeValuesDouble()
+    values.default_value = 0
+    values.no_value = 0
+    attribute_id = grid.vertex_attribute_manager().create_attribute_variable_double( scalar_function_name, values,properties )
     attribute = grid.vertex_attribute_manager().find_attribute_variable_double( attribute_id )
     attribute.set_value( 1, 1 )
     attribute.set_value( 4, 1 )
@@ -81,7 +88,14 @@ def test_gradient_triangulated_surface2D():
     builder.create_polygon( [ 5, 6, 8 ] )
     builder.compute_polygon_adjacencies()
     scalar_function_name = "scalar_function"
-    attribute_id = surface.vertex_attribute_manager().create_attribute_variable_double( scalar_function_name, 0,opengeode_py_basic.AttributeProperties() )
+    properties = opengeode_py_basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = opengeode_py_basic.AttributeValuesDouble()
+    values.default_value = 0
+    values.no_value = 0
+    attribute_id = surface.vertex_attribute_manager().create_attribute_variable_double( scalar_function_name, values,properties )
     attribute = surface.vertex_attribute_manager().find_attribute_variable_double( attribute_id )
     attribute.set_value( 1, 1 )
     attribute.set_value( 2, 1 )
@@ -100,7 +114,14 @@ def test_gradient_grid3D():
     builder = mesh.RegularGridBuilder3D.create( grid )
     builder.initialize_cartesian_grid( geom.Point3D([ 0, 0, 0 ]), [ 2, 2, 2 ], 1 )
     scalar_function_name = "scalar_function"
-    attribute_id = grid.vertex_attribute_manager().create_attribute_variable_double( scalar_function_name, 0,opengeode_py_basic.AttributeProperties() )
+    properties = opengeode_py_basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = opengeode_py_basic.AttributeValuesDouble()
+    values.default_value = 0
+    values.no_value = 0
+    attribute_id = grid.vertex_attribute_manager().create_attribute_variable_double( scalar_function_name, values,properties )
     attribute = grid.vertex_attribute_manager().find_attribute_variable_double( attribute_id )
     attribute.set_value( 4, 1 )
     attribute.set_value( 10, 1 )

--- a/bindings/python/tests/mesh/test-py-light-regular-grid.py
+++ b/bindings/python/tests/mesh/test-py-light-regular-grid.py
@@ -287,8 +287,15 @@ def test_closest_vertex(grid):
 
 
 def test_attribute_3d(grid):
+    properties = geode.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    first_values = geode.AttributeValuesDouble()
+    first_values.default_value = -1
+    first_values.no_value = -1
     attribute_id = grid.cell_attribute_manager().create_attribute_variable_double(
-        "toto", -1,geode.AttributeProperties()
+        "toto", first_values,properties
     )
     attribute = grid.cell_attribute_manager().find_attribute_variable_double(attribute_id)
     attribute.set_value(10, 10)
@@ -299,9 +306,12 @@ def test_attribute_3d(grid):
         raise ValueError("[Test] Wrong attribute value")
     if attribute.value(grid.nb_cells() - 1) != -1:
         raise ValueError("[Test] Wrong attribute value")
+    second_values = geode.AttributeValuesDouble()
+    second_values.default_value = 1
+    second_values.no_value = 1
     attribute_id = (
         grid.grid_vertex_attribute_manager().create_attribute_variable_double(
-            "toto_vertex", 1,geode.AttributeProperties()
+            "toto_vertex", second_values,properties
         )
     )
     attribute = grid.grid_vertex_attribute_manager().find_attribute_variable_double(
@@ -318,8 +328,15 @@ def test_attribute_3d(grid):
 
 def test_attribute_2d():
     grid = mesh.LightRegularGrid2D(geom.Point2D([1.5, 0]), [5, 10], [1.0, 2.0])
+    properties = geode.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    first_values = geode.AttributeValuesDouble()
+    first_values.default_value = -1
+    first_values.no_value = -1
     attribute_id = grid.cell_attribute_manager().create_attribute_variable_double(
-        "toto", -1,geode.AttributeProperties()
+        "toto", first_values,properties
     )
     attribute = grid.cell_attribute_manager().find_attribute_variable_double(attribute_id)
     attribute.set_value(10, 10)
@@ -330,9 +347,12 @@ def test_attribute_2d():
         raise ValueError("[Test] Wrong attribute value")
     if attribute.value(grid.nb_cells() - 1) != -1:
         raise ValueError("[Test] Wrong attribute value")
+    second_values = geode.AttributeValuesDouble()
+    second_values.default_value = 1
+    second_values.no_value = 1
     attribute_id = (
         grid.grid_vertex_attribute_manager().create_attribute_variable_double(
-            "toto_vertex", 1,geode.AttributeProperties()
+            "toto_vertex",second_values,properties
         )
     )
     attribute = grid.grid_vertex_attribute_manager().find_attribute_variable_double(

--- a/bindings/python/tests/mesh/test-py-point-set.py
+++ b/bindings/python/tests/mesh/test-py-point-set.py
@@ -58,8 +58,15 @@ def test_bounding_box(point_set):
 
 def test_create_vertex_attribute(point_set):
     manager = point_set.vertex_attribute_manager()
+    properties = opengeode_py_basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = opengeode_py_basic.AttributeValuesBool()
+    values.default_value = True
+    values.no_value = True
     attribute_id = point_set.vertex_attribute_manager(
-    ).create_attribute_constant_bool("test", True,opengeode_py_basic.AttributeProperties())
+    ).create_attribute_constant_bool("test", values,properties)
     attribute = manager.find_attribute_constant_bool(attribute_id)
     if attribute.constant_value() != True:
         raise ValueError("[Test] PointSet attribute value should be true")

--- a/bindings/python/tests/mesh/test-py-polygonal-surface.py
+++ b/bindings/python/tests/mesh/test-py-polygonal-surface.py
@@ -66,8 +66,15 @@ def test_create_polygons(polygonal_surface, builder):
 
 
 def test_create_edge_attribute(polygonal_surface):
+    properties = basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = basic.AttributeValuesUInt()
+    values.default_value = basic.NO_ID
+    values.no_value = basic.NO_ID
     attribute_id = polygonal_surface.edges().edge_attribute_manager(
-    ).create_attribute_variable_uint("test", basic.NO_ID,basic.AttributeProperties())
+    ).create_attribute_variable_uint("test", values,properties)
     attribute = polygonal_surface.edges().edge_attribute_manager(
     ).find_attribute_variable_uint(attribute_id)
     for e in range(polygonal_surface.edges().nb_edges()):

--- a/bindings/python/tests/mesh/test-py-polyhedral-solid.py
+++ b/bindings/python/tests/mesh/test-py-polyhedral-solid.py
@@ -72,8 +72,15 @@ def test_create_polyhedra(polyhedral_solid, builder):
 
 
 def test_create_facet_attribute(polyhedral_solid):
+    properties = basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = basic.AttributeValuesUInt()
+    values.default_value = basic.NO_ID
+    values.no_value = basic.NO_ID
     attribute_id = polyhedral_solid.facets().facet_attribute_manager(
-    ).create_attribute_variable_uint("test", basic.NO_ID, basic.AttributeProperties())
+    ).create_attribute_variable_uint("test", values, properties)
     attribute = polyhedral_solid.facets().facet_attribute_manager(
     ).find_attribute_variable_uint(attribute_id)
     for f in range(polyhedral_solid.facets().nb_facets()):
@@ -82,8 +89,15 @@ def test_create_facet_attribute(polyhedral_solid):
 
 
 def test_create_edge_attribute(polyhedral_solid):
+    properties = basic.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    values = basic.AttributeValuesUInt()
+    values.default_value = basic.NO_ID
+    values.no_value = basic.NO_ID
     attribute_id = polyhedral_solid.edges().edge_attribute_manager(
-    ).create_attribute_variable_uint("test", basic.NO_ID, basic.AttributeProperties())
+    ).create_attribute_variable_uint("test", values, properties)
     attribute = polyhedral_solid.edges().edge_attribute_manager(
     ).find_attribute_variable_uint(attribute_id)
     for e in range(polyhedral_solid.edges().nb_edges()):

--- a/bindings/python/tests/mesh/test-py-regular-grid.py
+++ b/bindings/python/tests/mesh/test-py-regular-grid.py
@@ -246,17 +246,27 @@ def test_closest_vertex(grid):
 def test_clone(grid):
     attribute_name = "int_attribute"
     attribute_name_d = "double_attribute"
+    properties = geode.AttributeProperties()
+    properties.assignable = False
+    properties.interpolable = False
+    properties.transferable = True
+    int_values = geode.AttributeValuesInt()
+    int_values.default_value = 0
+    int_values.no_value = 0
     attribute_id = (
         grid.polyhedron_attribute_manager().create_attribute_variable_int(
-            attribute_name, 0,geode.AttributeProperties()
+            attribute_name, int_values, properties
         )
     )
     attribute = grid.polyhedron_attribute_manager().find_attribute_variable_int(
         attribute_id
     )
+    double_values = geode.AttributeValuesDouble()
+    double_values.default_value = 0
+    double_values.no_value = 0
     attribute_d_id = (
         grid.vertex_attribute_manager().create_attribute_variable_double(
-            attribute_name_d, 0,geode.AttributeProperties()
+            attribute_name_d, double_values,properties
         )
     )
     attribute_d = grid.vertex_attribute_manager().find_attribute_variable_double(

--- a/include/geode/basic/attribute.hpp
+++ b/include/geode/basic/attribute.hpp
@@ -70,6 +70,8 @@ namespace geode
 
         [[nodiscard]] virtual std::string_view type() = 0;
 
+        [[nodiscard]] virtual bool has_value( index_t element ) const = 0;
+
         [[nodiscard]] const AttributeProperties& properties() const
         {
             return properties_;
@@ -171,6 +173,8 @@ namespace geode
 
     public:
         [[nodiscard]] virtual const T& value( index_t element ) const = 0;
+
+        [[nodiscard]] bool has_value( index_t element ) const override = 0;
 
         [[nodiscard]] std::string_view type() final
         {

--- a/include/geode/basic/attribute_manager.hpp
+++ b/include/geode/basic/attribute_manager.hpp
@@ -114,7 +114,7 @@ namespace geode
         template < template < typename > class Attribute, typename T >
         void create_attribute( std::string_view attribute_name,
             const geode::uuid& attribute_id,
-            T default_value,
+            AttributeValues< T > default_values,
             AttributeProperties properties )
         {
             absl::MutexLock lock{ mutex() };
@@ -127,7 +127,7 @@ namespace geode
                 "[AttributeManager::create_attribute] Attribute with id '",
                 attribute_id.string(), "' already exists." );
             typed_attribute = std::make_unique< Attribute< T > >(
-                std::move( default_value ), attribute_name,
+                std::move( default_values ), attribute_name,
                 std::move( properties ), AttributeBase::AttributeKey{} );
             IdentifierBuilder builder{ *typed_attribute };
             builder.set_id( attribute_id );
@@ -137,12 +137,12 @@ namespace geode
         template < template < typename > class Attribute, typename T >
         [[nodiscard]] geode::uuid create_attribute(
             std::string_view attribute_name,
-            T default_value,
+            AttributeValues< T > default_values,
             AttributeProperties properties )
         {
             geode::uuid attribute_id;
             create_attribute< Attribute, T >( attribute_name, attribute_id,
-                std::move( default_value ), std::move( properties ) );
+                std::move( default_values ), std::move( properties ) );
             return attribute_id;
         }
 

--- a/include/geode/basic/attribute_utils.hpp
+++ b/include/geode/basic/attribute_utils.hpp
@@ -45,19 +45,6 @@ namespace geode
     {
         AttributeProperties() = default;
 
-        AttributeProperties( bool is_assignable, bool is_interpolable )
-            : assignable( is_assignable ), interpolable( is_interpolable )
-        {
-        }
-
-        AttributeProperties(
-            bool is_assignable, bool is_interpolable, bool is_transferable )
-            : assignable( is_assignable ),
-              interpolable( is_interpolable ),
-              transferable( is_transferable )
-        {
-        }
-
         template < typename Archive >
         void serialize( Archive& serializer )
         {
@@ -78,6 +65,26 @@ namespace geode
         bool assignable{ false };
         bool interpolable{ false };
         bool transferable{ true };
+    };
+
+    template < typename AttributeType >
+    struct AttributeValues
+    {
+        AttributeValues() = default;
+
+        template < typename Archive >
+        void serialize( Archive& serializer )
+        {
+            serializer.ext(
+                *this, Growable< Archive, AttributeValues >{
+                           { []( Archive& archive, AttributeValues& values ) {
+                               archive( values.default_value );
+                               archive( values.no_value );
+                           } } } );
+        }
+
+        AttributeType default_value;
+        AttributeType no_value;
     };
 
     /*!
@@ -105,7 +112,7 @@ namespace geode
             const AttributeLinearInterpolation& /*unused*/,
             const Attribute< AttributeType >& attribute )
         {
-            return attribute.default_value();
+            return attribute.default_values().default_value;
         }
     };
 

--- a/include/geode/basic/cached_value.hpp
+++ b/include/geode/basic/cached_value.hpp
@@ -84,6 +84,15 @@ namespace geode
             return value_;
         }
 
+        bool operator==( const CachedValue& other ) const
+        {
+            if( computed() && other.computed() )
+            {
+                return value() == other.value();
+            }
+            return false;
+        }
+
         bool operator!=( const CachedValue& other ) const
         {
             if( computed() && other.computed() )

--- a/include/geode/basic/constant_attribute.hpp
+++ b/include/geode/basic/constant_attribute.hpp
@@ -56,12 +56,13 @@ namespace geode
         friend class bitsery::Access;
 
     public:
-        ConstantAttribute( T value,
+        ConstantAttribute( AttributeValues< T > values,
             std::string_view name,
             AttributeProperties properties,
             AttributeBase::AttributeKey /*key*/ )
-            : ConstantAttribute(
-                  std::move( value ), name, std::move( properties ) )
+            : ConstantAttribute( std::move( values.default_value ),
+                  name,
+                  std::move( properties ) )
         {
         }
 

--- a/include/geode/basic/constant_attribute.hpp
+++ b/include/geode/basic/constant_attribute.hpp
@@ -71,6 +71,11 @@ namespace geode
             return value_;
         }
 
+        [[nodiscard]] bool has_value( index_t /*unused*/ ) const override
+        {
+            return true;
+        }
+
         [[nodiscard]] const T& value() const
         {
             return value_;

--- a/include/geode/basic/sparse_attribute.hpp
+++ b/include/geode/basic/sparse_attribute.hpp
@@ -63,12 +63,12 @@ namespace geode
         friend class bitsery::Access;
 
     public:
-        SparseAttribute( T default_value,
+        SparseAttribute( AttributeValues< T > default_values,
             std::string_view name,
             AttributeProperties properties,
             AttributeBase::AttributeKey /*key*/ )
             : SparseAttribute(
-                  std::move( default_value ), name, std::move( properties ) )
+                  std::move( default_values ), name, std::move( properties ) )
         {
         }
 
@@ -79,7 +79,7 @@ namespace geode
             {
                 return value_it->second;
             }
-            return default_value_;
+            return default_values_.default_value;
         }
 
         void set_value( index_t element, T value )
@@ -87,15 +87,16 @@ namespace geode
             values_[element] = std::move( value );
         }
 
-        [[nodiscard]] const T& default_value() const
+        [[nodiscard]] const AttributeValues< T >& default_values() const
         {
-            return default_value_;
+            return default_values_;
         }
 
         template < typename Modifier >
         void modify_value( index_t element, Modifier modifier )
         {
-            auto [value_it, _] = values_.emplace( element, default_value_ );
+            auto [value_it, _] =
+                values_.emplace( element, default_values_.default_value );
             modifier( value_it->second );
         }
 
@@ -115,11 +116,11 @@ namespace geode
         }
 
     private:
-        SparseAttribute( T default_value,
+        SparseAttribute( AttributeValues< T > default_values,
             std::string_view name,
             AttributeProperties properties )
             : ReadOnlyAttribute< T >( name, std::move( properties ) ),
-              default_value_( std::move( default_value ) )
+              default_values_( std::move( default_values ) )
         {
             values_.reserve( 10 );
         }
@@ -140,18 +141,36 @@ namespace geode
             serializer.ext( *this,
                 Growable< Archive, SparseAttribute< T > >{
                     { []( Archive& archive, SparseAttribute< T >& attribute ) {
-                        archive.ext(
-                            attribute, bitsery::ext::BaseClass<
-                                           ReadOnlyAttribute< T > >{} );
-                        archive( attribute.default_value_ );
-                        archive.ext( attribute.values_,
-                            bitsery::ext::StdMap{
-                                attribute.values_.max_size() },
-                            []( Archive& archive2, index_t& i, T& item ) {
-                                archive2.value4b( i );
-                                archive2( item );
-                            } );
-                    } } } );
+                         archive.ext(
+                             attribute, bitsery::ext::BaseClass<
+                                            ReadOnlyAttribute< T > >{} );
+                         T old_default_value;
+                         archive( old_default_value );
+                         attribute.default_values_.default_value =
+                             old_default_value;
+                         attribute.default_values_.no_value = old_default_value;
+                         archive.ext( attribute.values_,
+                             bitsery::ext::StdMap{
+                                 attribute.values_.max_size() },
+                             []( Archive& archive2, index_t& i, T& item ) {
+                                 archive2.value4b( i );
+                                 archive2( item );
+                             } );
+                     },
+                        []( Archive& archive,
+                            SparseAttribute< T >& attribute ) {
+                            archive.ext(
+                                attribute, bitsery::ext::BaseClass<
+                                               ReadOnlyAttribute< T > >{} );
+                            archive( attribute.default_values_ );
+                            archive.ext( attribute.values_,
+                                bitsery::ext::StdMap{
+                                    attribute.values_.max_size() },
+                                []( Archive& archive2, index_t& i, T& item ) {
+                                    archive2.value4b( i );
+                                    archive2( item );
+                                } );
+                        } } } );
             values_.reserve( 10 );
         }
 
@@ -175,7 +194,8 @@ namespace geode
             values_.reserve( old_values.size() );
             for( auto& [index, value] : old_values )
             {
-                if( !to_delete[index] && value != default_value_ )
+                if( !to_delete[index]
+                    && value != default_values_.default_value )
                 {
                     values_.emplace( old2new[index], std::move( value ) );
                 }
@@ -199,7 +219,7 @@ namespace geode
         {
             std::shared_ptr< SparseAttribute< T > > attribute{
                 new SparseAttribute< T >{
-                    default_value_, this->name().value(), this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
             IdentifierBuilder builder{ *attribute };
             builder.set_id( this->id() );
@@ -213,12 +233,13 @@ namespace geode
         {
             const auto& typed_attribute =
                 dynamic_cast< const SparseAttribute< T >& >( attribute );
-            default_value_ = typed_attribute.default_value_;
+            default_values_ = typed_attribute.default_values_;
             if( nb_elements != 0 )
             {
                 for( const auto i : Range{ nb_elements } )
                 {
-                    if( typed_attribute.value( i ) != default_value_ )
+                    if( typed_attribute.value( i )
+                        != default_values_.default_value )
                     {
                         values_[i] = typed_attribute.value( i );
                     }
@@ -233,12 +254,13 @@ namespace geode
         {
             std::shared_ptr< SparseAttribute< T > > attribute{
                 new SparseAttribute< T >{
-                    default_value_, this->name().value(), this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
             for( const auto i : Indices{ old2new } )
             {
                 const auto new_index = old2new[i];
-                if( value( i ) != default_value_ && new_index != NO_ID )
+                if( value( i ) != default_values_.default_value
+                    && new_index != NO_ID )
                 {
                     OpenGeodeBasicException::check_exception(
                         new_index < nb_elements, nullptr,
@@ -259,11 +281,11 @@ namespace geode
         {
             std::shared_ptr< SparseAttribute< T > > attribute{
                 new SparseAttribute< T >{
-                    default_value_, this->name().value(), this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
             for( const auto& [in, outs] : old2new_mapping.in2out_map() )
             {
-                if( value( in ) != default_value_ )
+                if( value( in ) != default_values_.default_value )
                 {
                     for( const auto new_index : outs )
                     {
@@ -302,7 +324,8 @@ namespace geode
             for( const auto i : Indices{ old2new } )
             {
                 const auto new_index = old2new[i];
-                if( from.value( i ) != default_value_ && new_index != NO_ID )
+                if( from.value( i ) != default_values_.default_value
+                    && new_index != NO_ID )
                 {
                     this->set_value( new_index, from.value( i ) );
                 }
@@ -314,7 +337,7 @@ namespace geode
         {
             for( const auto& [in, outs] : old2new_mapping.in2out_map() )
             {
-                if( from.value( in ) != default_value_ )
+                if( from.value( in ) != default_values_.default_value )
                 {
                     for( const auto new_index : outs )
                     {
@@ -325,7 +348,7 @@ namespace geode
         }
 
     private:
-        T default_value_;
+        AttributeValues< T > default_values_;
         absl::flat_hash_map< index_t, T > values_{};
     };
 } // namespace geode

--- a/include/geode/basic/sparse_attribute.hpp
+++ b/include/geode/basic/sparse_attribute.hpp
@@ -82,6 +82,15 @@ namespace geode
             return default_values_.default_value;
         }
 
+        [[nodiscard]] bool has_value( index_t element ) const override
+        {
+            if( value( element ) == default_values_.no_value )
+            {
+                return false;
+            }
+            return true;
+        }
+
         void set_value( index_t element, T value )
         {
             values_[element] = std::move( value );

--- a/include/geode/basic/variable_attribute.hpp
+++ b/include/geode/basic/variable_attribute.hpp
@@ -71,6 +71,15 @@ namespace geode
             return values_[element];
         }
 
+        [[nodiscard]] bool has_value( index_t element ) const override
+        {
+            if( values_[element] == default_values_.no_value )
+            {
+                return false;
+            }
+            return true;
+        }
+
         void set_value( index_t element, T value )
         {
             values_[element] = std::move( value );
@@ -346,6 +355,15 @@ namespace geode
         [[nodiscard]] const bool& value( index_t element ) const override
         {
             return reinterpret_cast< const bool& >( values_[element] );
+        }
+
+        [[nodiscard]] bool has_value( index_t element ) const override
+        {
+            if( value( element ) == default_values_.no_value )
+            {
+                return false;
+            }
+            return true;
         }
 
         void set_value( index_t element, bool value )

--- a/include/geode/basic/variable_attribute.hpp
+++ b/include/geode/basic/variable_attribute.hpp
@@ -57,12 +57,12 @@ namespace geode
         friend class bitsery::Access;
 
     public:
-        VariableAttribute( T default_value,
+        VariableAttribute( AttributeValues< T > default_values,
             std::string_view name,
             AttributeProperties properties,
             AttributeBase::AttributeKey /*key*/ )
             : VariableAttribute(
-                  std::move( default_value ), name, std::move( properties ) )
+                  std::move( default_values ), name, std::move( properties ) )
         {
         }
 
@@ -76,9 +76,9 @@ namespace geode
             values_[element] = std::move( value );
         }
 
-        [[nodiscard]] const T& default_value() const
+        [[nodiscard]] const AttributeValues< T >& default_values() const
         {
-            return default_value_;
+            return default_values_;
         }
 
         template < typename Modifier >
@@ -108,11 +108,11 @@ namespace geode
         }
 
     protected:
-        VariableAttribute( T default_value,
+        VariableAttribute( AttributeValues< T > default_values,
             std::string_view name,
             AttributeProperties properties )
             : ReadOnlyAttribute< T >( name, std::move( properties ) ),
-              default_value_( std::move( default_value ) )
+              default_values_( std::move( default_values ) )
         {
             values_.reserve( 10 );
         }
@@ -126,20 +126,35 @@ namespace geode
         template < typename Archive >
         void serialize( Archive& serializer )
         {
-            serializer.ext(
-                *this, Growable< Archive, VariableAttribute< T > >{
-                           { []( Archive& archive,
-                                 VariableAttribute< T >& attribute ) {
-                               archive.ext(
-                                   attribute, bitsery::ext::BaseClass<
-                                                  ReadOnlyAttribute< T > >{} );
-                               archive( attribute.default_value_ );
-                               archive.container( attribute.values_,
-                                   attribute.values_.max_size(),
-                                   []( Archive& archive2, T& item ) {
-                                       archive2( item );
-                                   } );
-                           } } } );
+            serializer.ext( *this,
+                Growable< Archive, VariableAttribute< T > >{
+                    { []( Archive& archive,
+                          VariableAttribute< T >& attribute ) {
+                         T old_value;
+                         archive.ext(
+                             attribute, bitsery::ext::BaseClass<
+                                            ReadOnlyAttribute< T > >{} );
+                         archive( old_value );
+                         attribute.default_values_.default_value = old_value;
+                         attribute.default_values_.no_value = old_value;
+                         archive.container( attribute.values_,
+                             attribute.values_.max_size(),
+                             []( Archive& archive2, T& item ) {
+                                 archive2( item );
+                             } );
+                     },
+                        []( Archive& archive,
+                            VariableAttribute< T >& attribute ) {
+                            archive.ext(
+                                attribute, bitsery::ext::BaseClass<
+                                               ReadOnlyAttribute< T > >{} );
+                            archive( attribute.default_values_ );
+                            archive.container( attribute.values_,
+                                attribute.values_.max_size(),
+                                []( Archive& archive2, T& item ) {
+                                    archive2( item );
+                                } );
+                        } } } );
             values_.reserve( 10 );
         }
 
@@ -152,7 +167,7 @@ namespace geode
                 const auto next_capacity = capacity * 2;
                 values_.reserve( std::max( size, next_capacity ) );
             }
-            values_.resize( size, default_value_ );
+            values_.resize( size, default_values_.default_value );
         }
 
         void reserve(
@@ -178,7 +193,7 @@ namespace geode
         {
             std::shared_ptr< VariableAttribute< T > > attribute{
                 new VariableAttribute< T >{
-                    default_value_, this->name().value(), this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
             IdentifierBuilder builder{ *attribute };
             builder.set_id( this->id() );
@@ -192,10 +207,10 @@ namespace geode
         {
             const auto& typed_attribute =
                 dynamic_cast< const VariableAttribute< T >& >( attribute );
-            default_value_ = typed_attribute.default_value_;
+            default_values_ = typed_attribute.default_values_;
             if( nb_elements != 0 )
             {
-                values_.resize( nb_elements, default_value_ );
+                values_.resize( nb_elements, default_values_.default_value );
                 for( const auto i : Range{ nb_elements } )
                 {
                     values_[i] = typed_attribute.value( i );
@@ -210,9 +225,10 @@ namespace geode
         {
             std::shared_ptr< VariableAttribute< T > > attribute{
                 new VariableAttribute< T >{
-                    default_value_, this->name().value(), this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
-            attribute->values_.resize( nb_elements, default_value_ );
+            attribute->values_.resize(
+                nb_elements, default_values_.default_value );
             for( const auto i : Indices{ old2new } )
             {
                 const auto new_index = old2new[i];
@@ -240,9 +256,10 @@ namespace geode
         {
             std::shared_ptr< VariableAttribute< T > > attribute{
                 new VariableAttribute< T >{
-                    default_value_, this->name().value(), this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
-            attribute->values_.resize( nb_elements, default_value_ );
+            attribute->values_.resize(
+                nb_elements, default_values_.default_value );
             for( const auto& [input, outputs] : old2new_mapping.in2out_map() )
             {
                 for( const auto new_index : outputs )
@@ -303,7 +320,7 @@ namespace geode
         }
 
     private:
-        T default_value_;
+        AttributeValues< T > default_values_;
         std::vector< T > values_{};
     };
 
@@ -318,7 +335,7 @@ namespace geode
         friend class bitsery::Access;
 
     public:
-        VariableAttribute( bool default_value,
+        VariableAttribute( AttributeValues< bool > default_value,
             std::string_view name,
             AttributeProperties properties,
             AttributeBase::AttributeKey /*key*/ )
@@ -336,9 +353,9 @@ namespace geode
             values_[element] = std::move( value );
         }
 
-        [[nodiscard]] bool default_value() const
+        [[nodiscard]] AttributeValues< bool > default_values() const
         {
-            return default_value_;
+            return default_values_;
         }
 
         template < typename Modifier >
@@ -368,11 +385,11 @@ namespace geode
         }
 
     protected:
-        VariableAttribute( bool default_value,
+        VariableAttribute( AttributeValues< bool > default_values,
             std::string_view name,
             AttributeProperties properties )
             : ReadOnlyAttribute< bool >( name, std::move( properties ) ),
-              default_value_( default_value )
+              default_values_( default_values )
         {
             values_.reserve( 10 );
         }
@@ -392,13 +409,25 @@ namespace geode
                 Growable< Archive, VariableAttribute< bool > >{
                     { []( Archive& archive,
                           VariableAttribute< bool >& attribute ) {
-                        archive.ext(
-                            attribute, bitsery::ext::BaseClass<
-                                           ReadOnlyAttribute< bool > >{} );
-                        archive.value1b( attribute.default_value_ );
-                        archive.container1b(
-                            attribute.values_, attribute.values_.max_size() );
-                    } } } );
+                         bool old_value;
+                         archive.ext(
+                             attribute, bitsery::ext::BaseClass<
+                                            ReadOnlyAttribute< bool > >{} );
+                         archive.value1b( old_value );
+                         attribute.default_values_.default_value = old_value;
+                         attribute.default_values_.no_value = old_value;
+                         archive.container1b(
+                             attribute.values_, attribute.values_.max_size() );
+                     },
+                        []( Archive& archive,
+                            VariableAttribute< bool >& attribute ) {
+                            archive.ext(
+                                attribute, bitsery::ext::BaseClass<
+                                               ReadOnlyAttribute< bool > >{} );
+                            archive( attribute.default_values_ );
+                            archive.container1b( attribute.values_,
+                                attribute.values_.max_size() );
+                        } } } );
             values_.reserve( 10 );
         }
 
@@ -411,7 +440,8 @@ namespace geode
                 const auto next_capacity = capacity * 2;
                 values_.reserve( std::max( size, next_capacity ) );
             }
-            values_.resize( size, default_value_ );
+            values_.resize( size,
+                static_cast< unsigned char >( default_values_.default_value ) );
         }
 
         void reserve(
@@ -437,8 +467,7 @@ namespace geode
         {
             std::shared_ptr< VariableAttribute< bool > > attribute{
                 new VariableAttribute< bool >{
-                    static_cast< bool >( default_value_ ), this->name().value(),
-                    this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
             attribute->values_ = values_;
             return attribute;
@@ -450,7 +479,7 @@ namespace geode
         {
             const auto& typed_attribute =
                 dynamic_cast< const VariableAttribute< bool >& >( attribute );
-            default_value_ = typed_attribute.default_value_;
+            default_values_ = typed_attribute.default_values_;
             if( nb_elements != 0 )
             {
                 values_.resize( nb_elements );
@@ -468,10 +497,10 @@ namespace geode
         {
             std::shared_ptr< VariableAttribute< bool > > attribute{
                 new VariableAttribute< bool >{
-                    static_cast< bool >( default_value_ ), this->name().value(),
-                    this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
-            attribute->values_.resize( nb_elements, default_value_ );
+            attribute->values_.resize( nb_elements,
+                static_cast< unsigned char >( default_values_.default_value ) );
             for( const auto i : Indices{ old2new } )
             {
                 const auto new_index = old2new[i];
@@ -499,10 +528,10 @@ namespace geode
         {
             std::shared_ptr< VariableAttribute< bool > > attribute{
                 new VariableAttribute< bool >{
-                    static_cast< bool >( default_value_ ), this->name().value(),
-                    this->properties() }
+                    default_values_, this->name().value(), this->properties() }
             };
-            attribute->values_.resize( nb_elements, default_value_ );
+            attribute->values_.resize( nb_elements,
+                static_cast< unsigned char >( default_values_.default_value ) );
             for( const auto& [in, outs] : old2new_mapping.in2out_map() )
             {
                 for( const auto new_index : outs )
@@ -564,7 +593,7 @@ namespace geode
         }
 
     private:
-        unsigned char default_value_;
+        AttributeValues< bool > default_values_;
         std::vector< unsigned char > values_{};
     };
 } // namespace geode

--- a/include/geode/mesh/core/detail/facet_storage.hpp
+++ b/include/geode/mesh/core/detail/facet_storage.hpp
@@ -61,18 +61,28 @@ namespace geode
 
             FacetStorage()
             {
+                AttributeProperties attribute_properties;
+                attribute_properties.assignable = false;
+                attribute_properties.interpolable = false;
+                attribute_properties.transferable = false;
+                AttributeValues< index_t > counter_values;
+                counter_values.default_value = 1u;
+                counter_values.no_value = NO_ID;
                 const auto counter_attribute_id =
                     facet_attribute_manager_
                         .create_attribute< VariableAttribute, index_t >(
-                            "counter", 1u, { false, false, false } );
+                            "counter", counter_values, attribute_properties );
                 counter_ = facet_attribute_manager_
                                .find_attribute< VariableAttribute, index_t >(
                                    counter_attribute_id );
+                AttributeValues< VertexContainer > vertices_values;
+                vertices_values.default_value = VertexContainer{};
+                vertices_values.no_value = VertexContainer{};
                 const auto vertices_attribute_id =
                     facet_attribute_manager_
                         .create_attribute< VariableAttribute, VertexContainer >(
-                            "facet_vertices", VertexContainer{},
-                            { false, false, false } );
+                            "facet_vertices", vertices_values,
+                            attribute_properties );
                 vertices_ =
                     facet_attribute_manager_
                         .find_attribute< VariableAttribute, VertexContainer >(
@@ -244,10 +254,17 @@ namespace geode
             {
                 facet_attribute_manager_.copy( from.facet_attribute_manager() );
                 facet_indices_ = from.facet_indices_;
+                AttributeProperties attribute_properties;
+                attribute_properties.assignable = false;
+                attribute_properties.interpolable = false;
+                attribute_properties.transferable = false;
+                AttributeValues< index_t > counter_values;
+                counter_values.default_value = 1u;
+                counter_values.no_value = NO_ID;
                 const auto counter_id =
                     facet_attribute_manager_
                         .create_attribute< VariableAttribute, index_t >(
-                            "counter", 1u, { false, false, false } );
+                            "counter", counter_values, attribute_properties );
                 counter_ = facet_attribute_manager_
                                .find_attribute< VariableAttribute, index_t >(
                                    counter_id );
@@ -255,11 +272,14 @@ namespace geode
                     from.facet_attribute_manager()
                         .template find_read_only_attribute< index_t >(
                             from.counter_->id() );
+                AttributeValues< VertexContainer > vertices_values;
+                vertices_values.default_value = VertexContainer{};
+                vertices_values.no_value = VertexContainer{};
                 const auto vertices_id =
                     facet_attribute_manager_
                         .create_attribute< VariableAttribute, VertexContainer >(
-                            "facet_vertices", VertexContainer{},
-                            { false, false, false } );
+                            "facet_vertices", vertices_values,
+                            attribute_properties );
                 vertices_ =
                     facet_attribute_manager_
                         .find_attribute< VariableAttribute, VertexContainer >(

--- a/include/geode/mesh/core/internal/edges_impl.hpp
+++ b/include/geode/mesh/core/internal/edges_impl.hpp
@@ -41,12 +41,18 @@ namespace geode
 
             explicit EdgesImpl( Graph& graph ) : edges_()
             {
+                AttributeProperties attribute_properties;
+                attribute_properties.assignable = false;
+                attribute_properties.interpolable = false;
+                attribute_properties.transferable = false;
+                AttributeValues< std::array< index_t, 2 > > edges_values;
+                edges_values.default_value = { NO_ID, NO_ID };
+                edges_values.no_value = { NO_ID, NO_ID };
                 const auto edge_attribute_id =
                     graph.edge_attribute_manager()
                         .template create_attribute< VariableAttribute,
-                            std::array< index_t, 2 > >( "edges",
-                            std::array< index_t, 2 >{ NO_ID, NO_ID },
-                            { false, false, false } );
+                            std::array< index_t, 2 > >(
+                            "edges", edges_values, attribute_properties );
                 edges_ =
                     graph.edge_attribute_manager()
                         .template find_attribute< VariableAttribute,

--- a/include/geode/mesh/core/internal/points_impl.hpp
+++ b/include/geode/mesh/core/internal/points_impl.hpp
@@ -57,10 +57,17 @@ namespace geode
             PointsImpl(
                 AttributeManager& manager, std::string_view attribute_name )
             {
+                AttributeProperties attribute_properties;
+                attribute_properties.assignable = false;
+                attribute_properties.interpolable = false;
+                attribute_properties.transferable = false;
+                AttributeValues< Point< dimension > > points_values;
+                points_values.default_value = Point< dimension >{};
+                points_values.no_value = Point< dimension >{};
                 const auto attribute_id =
                     manager.template create_attribute< VariableAttribute,
-                        Point< dimension > >( attribute_name,
-                        Point< dimension >{}, { false, false, false } );
+                        Point< dimension > >(
+                        attribute_name, points_values, attribute_properties );
                 points_ = manager.template find_attribute< VariableAttribute,
                     Point< dimension > >( attribute_id );
             }

--- a/include/geode/mesh/core/internal/solid_mesh_impl.hpp
+++ b/include/geode/mesh/core/internal/solid_mesh_impl.hpp
@@ -51,6 +51,12 @@ namespace geode
                 return polyhedra != other.polyhedra;
             }
 
+            [[nodiscard]] bool operator==(
+                const PolyhedraAroundVertexImpl& other ) const
+            {
+                return !operator!=( other );
+            }
+
             friend class bitsery::Access;
             template < typename Archive >
             void serialize( Archive& serializer )

--- a/include/geode/mesh/core/internal/surface_mesh_impl.hpp
+++ b/include/geode/mesh/core/internal/surface_mesh_impl.hpp
@@ -51,6 +51,12 @@ namespace geode
                 return polygons != other.polygons;
             }
 
+            [[nodiscard]] bool operator==(
+                const PolygonsAroundVertexImpl& other ) const
+            {
+                return !operator!=( other );
+            }
+
             friend class bitsery::Access;
             template < typename Archive >
             void serialize( Archive& serializer )

--- a/include/geode/mesh/core/internal/texture_impl.hpp
+++ b/include/geode/mesh/core/internal/texture_impl.hpp
@@ -92,10 +92,17 @@ namespace geode
 
             TextureImpl( AttributeManager& manager, std::string_view name )
             {
+                AttributeProperties attribute_properties;
+                attribute_properties.assignable = false;
+                attribute_properties.interpolable = false;
+                attribute_properties.transferable = false;
+                AttributeValues< ElementTextureCoordinates > coordinates_values;
+                coordinates_values.default_value = {};
+                coordinates_values.no_value = {};
                 const auto texture_id =
                     manager.create_attribute< VariableAttribute,
                         ElementTextureCoordinates >(
-                        name, {}, geode::AttributeProperties{} );
+                        name, coordinates_values, attribute_properties );
                 coordinates_ = manager.find_attribute< VariableAttribute,
                     ElementTextureCoordinates >( texture_id );
             }

--- a/src/geode/mesh/builder/vertex_set_builder.cpp
+++ b/src/geode/mesh/builder/vertex_set_builder.cpp
@@ -75,12 +75,9 @@ namespace geode
 
     index_t VertexSetBuilder::create_vertices( index_t nb )
     {
-        DEBUG( "create_vertices" );
         const auto first_added_vertex = vertex_set_.nb_vertices();
-        DEBUG( vertex_set_.vertex_attribute_manager().nb_elements() );
         vertex_set_.vertex_attribute_manager().resize(
             first_added_vertex + nb );
-        DEBUG( vertex_set_.vertex_attribute_manager().nb_elements() );
         do_create_vertices( nb );
         return first_added_vertex;
     }

--- a/src/geode/mesh/core/geode/geode_tetrahedral_solid.cpp
+++ b/src/geode/mesh/core/geode/geode_tetrahedral_solid.cpp
@@ -51,12 +51,18 @@ namespace geode
         {
             detail::template initialize_crs<
                 OpenGeodeTetrahedralSolid< dimension > >( mesh );
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< std::array< index_t, 4 > > attribute_values;
+            attribute_values.default_value = { NO_ID, NO_ID, NO_ID, NO_ID };
+            attribute_values.no_value = { NO_ID, NO_ID, NO_ID, NO_ID };
             const auto tetrahedron_vertices_id =
                 mesh.polyhedron_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         std::array< index_t, 4 > >( "tetrahedron_vertices",
-                        std::array< index_t, 4 >{ NO_ID, NO_ID, NO_ID, NO_ID },
-                        { false, false, false } );
+                        attribute_values, attribute_properties );
             tetrahedron_vertices_ =
                 mesh.polyhedron_attribute_manager()
                     .template find_attribute< VariableAttribute,
@@ -65,8 +71,7 @@ namespace geode
                 mesh.polyhedron_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         std::array< index_t, 4 > >( "tetrahedron_adjacents",
-                        std::array< index_t, 4 >{ NO_ID, NO_ID, NO_ID, NO_ID },
-                        { false, false, false } );
+                        attribute_values, attribute_properties );
             tetrahedron_adjacents_ =
                 mesh.polyhedron_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/core/geode/geode_triangulated_surface.cpp
+++ b/src/geode/mesh/core/geode/geode_triangulated_surface.cpp
@@ -49,12 +49,18 @@ namespace geode
         {
             detail::template initialize_crs<
                 OpenGeodeTriangulatedSurface< dimension > >( mesh );
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< std::array< index_t, 3 > > attribute_values;
+            attribute_values.default_value = { NO_ID, NO_ID, NO_ID };
+            attribute_values.no_value = { NO_ID, NO_ID, NO_ID };
             const auto triangle_vertices_id =
                 mesh.polygon_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         std::array< index_t, 3 > >( "triangle_vertices",
-                        std::array< index_t, 3 >{ NO_ID, NO_ID, NO_ID },
-                        { false, false, false } );
+                        attribute_values, attribute_properties );
             triangle_vertices_ =
                 mesh.polygon_attribute_manager()
                     .template find_attribute< VariableAttribute,
@@ -63,8 +69,7 @@ namespace geode
                 mesh.polygon_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         std::array< index_t, 3 > >( "triangle_adjacents",
-                        std::array< index_t, 3 >{ NO_ID, NO_ID, NO_ID },
-                        { false, false, false } );
+                        attribute_values, attribute_properties );
             triangle_adjacents_ =
                 mesh.polygon_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/core/graph.cpp
+++ b/src/geode/mesh/core/graph.cpp
@@ -48,11 +48,18 @@ namespace geode
     public:
         explicit Impl( Graph& graph )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< EdgesAroundVertex > edges_around_vertex_values;
+            edges_around_vertex_values.default_value = EdgesAroundVertex{};
+            edges_around_vertex_values.no_value = EdgesAroundVertex{};
             const auto attribute_id =
                 graph.vertex_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         EdgesAroundVertex >( ATTRIBUTE_NAME,
-                        EdgesAroundVertex{}, { false, false, false } );
+                        edges_around_vertex_values, attribute_properties );
             edges_around_vertex_ =
                 graph.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/core/solid_mesh.cpp
+++ b/src/geode/mesh/core/solid_mesh.cpp
@@ -440,11 +440,18 @@ namespace geode
     public:
         explicit Impl( SolidMesh& solid )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< PolyhedronVertex > polyhedron_around_vertex_values;
+            polyhedron_around_vertex_values.default_value = PolyhedronVertex{};
+            polyhedron_around_vertex_values.no_value = PolyhedronVertex{};
             const auto attribute_id =
                 solid.vertex_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         PolyhedronVertex >( "polyhedron_around_vertex",
-                        PolyhedronVertex{}, { false, false, false } );
+                        polyhedron_around_vertex_values, attribute_properties );
             polyhedron_around_vertex_ =
                 solid.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,
@@ -681,11 +688,18 @@ namespace geode
         void initialize_polyhedra_around_vertex(
             const SolidMesh< dimension >& solid )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< CachedPolyhedra > polyhedron_around_vertex_values;
+            polyhedron_around_vertex_values.default_value = CachedPolyhedra{};
+            polyhedron_around_vertex_values.no_value = CachedPolyhedra{};
             const auto attribute_id =
                 solid.vertex_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         CachedPolyhedra >( POLYHEDRA_AROUND_VERTEX_NAME,
-                        CachedPolyhedra{}, { false, false, false } );
+                        polyhedron_around_vertex_values, attribute_properties );
             polyhedra_around_vertex_ =
                 solid.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/core/surface_mesh.cpp
+++ b/src/geode/mesh/core/surface_mesh.cpp
@@ -285,11 +285,18 @@ namespace geode
     public:
         Impl( SurfaceMesh& surface )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< PolygonVertex > polygon_around_vertex_values;
+            polygon_around_vertex_values.default_value = PolygonVertex{};
+            polygon_around_vertex_values.no_value = PolygonVertex{};
             const auto attribute_id =
                 surface.vertex_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         PolygonVertex >( "polygon_around_vertex",
-                        PolygonVertex{}, { false, false, false } );
+                        polygon_around_vertex_values, attribute_properties );
             polygon_around_vertex_ =
                 surface.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,
@@ -436,11 +443,18 @@ namespace geode
         void initialize_polygons_around_vertex(
             const SurfaceMesh< dimension >& surface )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< CachedPolygons > polygon_around_vertex_values;
+            polygon_around_vertex_values.default_value = CachedPolygons{};
+            polygon_around_vertex_values.no_value = CachedPolygons{};
             const auto attribute_id =
                 surface.vertex_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         CachedPolygons >( POLYGONS_AROUND_VERTEX_NAME,
-                        CachedPolygons{}, { false, false, false } );
+                        polygon_around_vertex_values, attribute_properties );
             polygons_around_vertex_ =
                 surface.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/helpers/convert_grid.cpp
+++ b/src/geode/mesh/helpers/convert_grid.cpp
@@ -51,10 +51,17 @@ namespace geode
             cells_number, cells_directions };
         IdentifierBuilder builder{ grid };
         internal::copy_meta_info( raster, builder );
+        AttributeProperties attribute_properties;
+        attribute_properties.assignable = false;
+        attribute_properties.interpolable = false;
+        attribute_properties.transferable = true;
+        AttributeValues< RGBColor > color_values;
+        color_values.default_value = RGBColor{};
+        color_values.no_value = RGBColor{};
         auto color_attribute_id =
             grid.cell_attribute_manager()
                 .template create_attribute< VariableAttribute, RGBColor >(
-                    "RGB_data", {}, geode::AttributeProperties{} );
+                    "RGB_data", color_values, attribute_properties );
         auto color =
             grid.cell_attribute_manager()
                 .template find_attribute< VariableAttribute, RGBColor >(

--- a/src/geode/mesh/helpers/euclidean_distance_transform.cpp
+++ b/src/geode/mesh/helpers/euclidean_distance_transform.cpp
@@ -43,11 +43,19 @@ namespace geode
             std::string_view distance_map_name )
             : grid_( grid ), squared_cell_length_{}
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = true;
+            AttributeValues< double > distance_map_values;
+            distance_map_values.default_value =
+                std::numeric_limits< double >::max();
+            distance_map_values.no_value = std::numeric_limits< double >::max();
             const auto distance_map_id =
                 grid.cell_attribute_manager()
                     .template create_attribute< VariableAttribute, double >(
-                        distance_map_name, std::numeric_limits< double >::max(),
-                        geode::AttributeProperties{} );
+                        distance_map_name, distance_map_values,
+                        attribute_properties );
             distance_map_ =
                 grid.cell_attribute_manager()
                     .template find_attribute< VariableAttribute, double >(

--- a/src/geode/mesh/helpers/gradient_computation.cpp
+++ b/src/geode/mesh/helpers/gradient_computation.cpp
@@ -69,14 +69,21 @@ namespace
         std::tuple< geode::uuid, std::vector< geode::index_t > >
             compute_scalar_function_gradient() const
         {
+            geode::AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = true;
+            geode::AttributeValues< geode::Vector< Mesh::dim > >
+                distance_map_values;
+            distance_map_values.default_value = geode::Vector< Mesh::dim >{};
+            distance_map_values.no_value = geode::Vector< Mesh::dim >{};
             const auto gradient_function_name =
                 absl::StrCat( scalar_function_->name().value(), "_gradient" );
             auto gradient_function_id =
                 mesh_.vertex_attribute_manager()
                     .template create_attribute< geode::VariableAttribute,
                         geode::Vector< Mesh::dim > >( gradient_function_name,
-                        geode::Vector< Mesh::dim >{},
-                        geode::AttributeProperties{} );
+                        distance_map_values, attribute_properties );
             auto gradient_function =
                 mesh_.vertex_attribute_manager()
                     .template find_attribute< geode::VariableAttribute,

--- a/src/geode/mesh/helpers/grid_point_function.cpp
+++ b/src/geode/mesh/helpers/grid_point_function.cpp
@@ -44,11 +44,19 @@ namespace geode
             Point< point_dimension > value )
             : grid_( grid )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = true;
+            attribute_properties.transferable = true;
+            AttributeValues< Point< point_dimension > >
+                function_attribute_values;
+            function_attribute_values.default_value = value;
+            function_attribute_values.no_value = Point< point_dimension >{};
             const auto function_id =
                 grid_.grid_vertex_attribute_manager()
                     .template create_attribute< VariableAttribute,
-                        Point< point_dimension > >(
-                        function_name, std::move( value ), { false, true } );
+                        Point< point_dimension > >( function_name,
+                        function_attribute_values, attribute_properties );
             function_attribute_ =
                 grid_.grid_vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,
@@ -58,11 +66,20 @@ namespace geode
         Impl( const Grid< dimension >& grid, std::string_view attribute_name )
             : grid_( grid )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = true;
+            attribute_properties.transferable = true;
+            AttributeValues< Point< point_dimension > >
+                function_attribute_values;
+            function_attribute_values.default_value =
+                Point< point_dimension >{};
+            function_attribute_values.no_value = Point< point_dimension >{};
             const auto attribute_id =
                 grid_.grid_vertex_attribute_manager()
                     .template create_attribute< VariableAttribute,
                         Point< point_dimension > >( attribute_name,
-                        Point< point_dimension >(), { false, true } );
+                        function_attribute_values, attribute_properties );
             function_attribute_ =
                 grid_.grid_vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/helpers/grid_scalar_function.cpp
+++ b/src/geode/mesh/helpers/grid_scalar_function.cpp
@@ -44,10 +44,19 @@ namespace geode
             double value )
             : grid_( grid )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = true;
+            attribute_properties.transferable = true;
+            AttributeValues< double > function_attribute_values;
+            function_attribute_values.default_value = value;
+            function_attribute_values.no_value =
+                std::numeric_limits< double >::max();
             const auto function_id =
                 grid_.grid_vertex_attribute_manager()
                     .template create_attribute< VariableAttribute, double >(
-                        function_name, value, { false, true } );
+                        function_name, function_attribute_values,
+                        attribute_properties );
             function_attribute_ =
                 grid_.grid_vertex_attribute_manager()
                     .template find_attribute< VariableAttribute, double >(

--- a/src/geode/mesh/helpers/tetrahedral_solid_point_function.cpp
+++ b/src/geode/mesh/helpers/tetrahedral_solid_point_function.cpp
@@ -45,10 +45,18 @@ namespace geode
             Point< point_dimension > value )
             : solid_( solid )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = true;
+            attribute_properties.transferable = true;
+            AttributeValues< Point< point_dimension > >
+                function_attribute_values;
+            function_attribute_values.default_value = value;
+            function_attribute_values.no_value = Point< point_dimension >{};
             solid_.vertex_attribute_manager()
                 .template create_attribute< VariableAttribute,
                     Point< point_dimension > >( function_name, function_id,
-                    std::move( value ), { false, true } );
+                    function_attribute_values, attribute_properties );
             function_attribute_ =
                 solid_.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/helpers/tetrahedral_solid_scalar_function.cpp
+++ b/src/geode/mesh/helpers/tetrahedral_solid_scalar_function.cpp
@@ -44,9 +44,18 @@ namespace geode
             double value )
             : solid_( solid )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = true;
+            attribute_properties.transferable = true;
+            AttributeValues< double > function_attribute_values;
+            function_attribute_values.default_value = value;
+            function_attribute_values.no_value =
+                std::numeric_limits< double >::max();
             solid_.vertex_attribute_manager()
                 .template create_attribute< VariableAttribute, double >(
-                    function_name, function_id, value, { false, true } );
+                    function_name, function_id, function_attribute_values,
+                    attribute_properties );
             function_attribute_ =
                 solid_.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute, double >(

--- a/src/geode/mesh/helpers/triangulated_surface_point_function.cpp
+++ b/src/geode/mesh/helpers/triangulated_surface_point_function.cpp
@@ -45,10 +45,18 @@ namespace geode
             Point< point_dimension > value )
             : surface_( surface )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = true;
+            attribute_properties.transferable = true;
+            AttributeValues< Point< point_dimension > >
+                function_attribute_values;
+            function_attribute_values.default_value = value;
+            function_attribute_values.no_value = Point< point_dimension >{};
             surface_.vertex_attribute_manager()
                 .template create_attribute< VariableAttribute,
                     Point< point_dimension > >( function_name, function_id,
-                    std::move( value ), { false, true } );
+                    function_attribute_values, attribute_properties );
             function_attribute_ =
                 surface_.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute,

--- a/src/geode/mesh/helpers/triangulated_surface_scalar_function.cpp
+++ b/src/geode/mesh/helpers/triangulated_surface_scalar_function.cpp
@@ -45,9 +45,18 @@ namespace geode
             double value )
             : surface_( surface )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = true;
+            attribute_properties.transferable = true;
+            AttributeValues< double > function_attribute_values;
+            function_attribute_values.default_value = value;
+            function_attribute_values.no_value =
+                std::numeric_limits< double >::max();
             surface_.vertex_attribute_manager()
                 .template create_attribute< VariableAttribute, double >(
-                    function_name, function_id, value, { false, true } );
+                    function_name, function_id, function_attribute_values,
+                    attribute_properties );
             function_attribute_ =
                 surface_.vertex_attribute_manager()
                     .template find_attribute< VariableAttribute, double >(

--- a/src/geode/model/mixin/core/detail/relationships_impl.cpp
+++ b/src/geode/model/mixin/core/detail/relationships_impl.cpp
@@ -244,10 +244,17 @@ namespace geode
                                ids.value()[0] );
                 return;
             }
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = true;
+            AttributeValues< ComponentID > ids_attribute_values;
+            ids_attribute_values.default_value = ComponentID{};
+            ids_attribute_values.no_value = ComponentID{};
             const auto id =
                 graph_->vertex_attribute_manager()
                     .create_attribute< VariableAttribute, ComponentID >(
-                        "id", ComponentID{}, AttributeProperties{} );
+                        "id", ids_attribute_values, attribute_properties );
             ids_ = graph_->vertex_attribute_manager()
                        .find_attribute< VariableAttribute, ComponentID >( id );
         }

--- a/src/geode/model/mixin/core/relationships.cpp
+++ b/src/geode/model/mixin/core/relationships.cpp
@@ -252,10 +252,18 @@ namespace geode
                             ids.value()[0] );
                 return;
             }
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = true;
+            AttributeValues< RelationType > ids_attribute_values;
+            ids_attribute_values.default_value = NO_ID;
+            ids_attribute_values.no_value = NO_ID;
             const auto id =
                 relation_attribute_manager()
                     .create_attribute< VariableAttribute, RelationType >(
-                        "relation_type", NO_ID, geode::AttributeProperties{} );
+                        "relation_type", ids_attribute_values,
+                        attribute_properties );
             relation_type_ =
                 relation_attribute_manager()
                     .find_attribute< VariableAttribute, RelationType >( id );

--- a/src/geode/model/mixin/core/vertex_identifier.cpp
+++ b/src/geode/model/mixin/core/vertex_identifier.cpp
@@ -107,13 +107,21 @@ namespace geode
     public:
         Impl()
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< std::vector< ComponentMeshVertex > >
+                component_vertices_attribute_values;
+            component_vertices_attribute_values.default_value = {};
+            component_vertices_attribute_values.no_value = {};
             const auto unique_vertices_attribute_id =
                 unique_vertices_.vertex_attribute_manager()
                     .create_attribute< VariableAttribute,
                         std::vector< ComponentMeshVertex > >(
                         "component vertices",
-                        std::vector< ComponentMeshVertex >{},
-                        { false, false, false } );
+                        component_vertices_attribute_values,
+                        attribute_properties );
             component_vertices_ = unique_vertices_.vertex_attribute_manager()
                                       .find_attribute< VariableAttribute,
                                           std::vector< ComponentMeshVertex > >(
@@ -181,11 +189,19 @@ namespace geode
         template < typename MeshComponent >
         void register_component( const MeshComponent& component )
         {
+            AttributeProperties attribute_properties;
+            attribute_properties.assignable = false;
+            attribute_properties.interpolable = false;
+            attribute_properties.transferable = false;
+            AttributeValues< index_t > unqiue_vertex_attribute_values;
+            unqiue_vertex_attribute_values.default_value = NO_ID;
+            unqiue_vertex_attribute_values.no_value = NO_ID;
             const auto& mesh = component.mesh();
             const auto unique_vertices_attribute_id =
                 mesh.vertex_attribute_manager()
                     .template create_attribute< VariableAttribute, index_t >(
-                        UNIQUE_VERTICES_NAME, NO_ID, { false, false, false } );
+                        UNIQUE_VERTICES_NAME, unqiue_vertex_attribute_values,
+                        attribute_properties );
             const auto [_, inserted] =
                 vertex2unique_vertex_.emplace( component.id(),
                     mesh.vertex_attribute_manager()
@@ -204,7 +220,6 @@ namespace geode
             const auto unique_vertices_ids =
                 mesh.vertex_attribute_manager().attribute_ids_matching_name(
                     UNIQUE_VERTICES_NAME );
-            DEBUG( unique_vertices_ids.has_value() );
             OpenGeodeModelException::check_exception(
                 unique_vertices_ids.has_value(), nullptr,
                 OpenGeodeException::TYPE::data,

--- a/tests/basic/test-attribute.cpp
+++ b/tests/basic/test-attribute.cpp
@@ -109,8 +109,15 @@ namespace geode
 void test_constant_attribute(
     geode::AttributeManager& manager, const geode::uuid& attribute_id )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = true;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< bool > attribute_values;
+    attribute_values.default_value = true;
+    attribute_values.no_value = true;
     manager.create_attribute< geode::ConstantAttribute, bool >(
-        "bool", attribute_id, true, { true, true } );
+        "bool", attribute_id, attribute_values, attribute_properties );
     auto constant_attribute =
         manager.find_attribute< geode::ConstantAttribute, bool >(
             attribute_id );
@@ -134,8 +141,15 @@ void test_constant_attribute(
 void test_foo_constant_attribute(
     geode::AttributeManager& manager, const geode::uuid& attribute_id )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = false;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< Foo > attribute_values;
+    attribute_values.default_value = Foo{};
+    attribute_values.no_value = Foo{};
     manager.create_attribute< geode::ConstantAttribute, Foo >(
-        "foo", attribute_id, Foo{}, geode::AttributeProperties{} );
+        "foo", attribute_id, attribute_values, attribute_properties );
     auto constant_attribute =
         manager.find_attribute< geode::ConstantAttribute, Foo >( attribute_id );
     constant_attribute->modify_value( []( Foo& foo ) {
@@ -149,8 +163,15 @@ void test_foo_constant_attribute(
 void test_foo_variable_attribute(
     geode::AttributeManager& manager, const geode::uuid& attribute_id )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = false;
+    attribute_properties.transferable = false;
+    geode::AttributeValues< Foo > attribute_values;
+    attribute_values.default_value = Foo{};
+    attribute_values.no_value = Foo{};
     manager.create_attribute< geode::VariableAttribute, Foo >(
-        "foo2", attribute_id, Foo{}, { false, false, false } );
+        "foo2", attribute_id, attribute_values, attribute_properties );
     auto variable_attribute =
         manager.find_attribute< geode::VariableAttribute, Foo >( attribute_id );
     manager.set_attribute_properties( attribute_id, { true, false, true } );
@@ -180,12 +201,20 @@ void test_foo_variable_attribute(
 void test_int_variable_attribute(
     geode::AttributeManager& manager, const geode::uuid& attribute_id )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = true;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< int > attribute_values;
+    attribute_values.default_value = 12;
+    attribute_values.no_value = geode::NO_ID;
     manager.create_attribute< geode::VariableAttribute, int >(
-        "int", attribute_id, 12, { true, true } );
+        "int", attribute_id, attribute_values, attribute_properties );
     auto variable_attribute =
         manager.find_attribute< geode::VariableAttribute, int >( attribute_id );
     geode::OpenGeodeBasicException::test(
-        variable_attribute->default_value() == 12, "Wrong default value" );
+        variable_attribute->default_values().default_value == 12,
+        "Wrong default value" );
     variable_attribute->set_value( 3, 3 );
 
     const auto attribute =
@@ -203,8 +232,15 @@ void test_int_variable_attribute(
 void test_foo_sparse_attribute(
     geode::AttributeManager& manager, const geode::uuid& attribute_id )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = false;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< Foo > attribute_values;
+    attribute_values.default_value = Foo{};
+    attribute_values.no_value = Foo{};
     manager.create_attribute< geode::SparseAttribute, Foo >(
-        "foo", attribute_id, Foo{}, geode::AttributeProperties{} );
+        "foo", attribute_id, attribute_values, attribute_properties );
     auto sparse_attribute =
         manager.find_attribute< geode::SparseAttribute, Foo >( attribute_id );
     sparse_attribute->modify_value( 3, []( Foo& foo ) {
@@ -226,13 +262,21 @@ void test_foo_sparse_attribute(
 void test_double_sparse_attribute(
     geode::AttributeManager& manager, const geode::uuid& attribute_id )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = true;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< double > attribute_values;
+    attribute_values.default_value = 12.;
+    attribute_values.no_value = geode::NO_ID;
     manager.create_attribute< geode::SparseAttribute, double >(
-        "double", attribute_id, 12., { true, true } );
+        "double", attribute_id, attribute_values, attribute_properties );
     auto sparse_attribute =
         manager.find_attribute< geode::SparseAttribute, double >(
             attribute_id );
     geode::OpenGeodeBasicException::test(
-        sparse_attribute->default_value() == 12, "Wrong default value" );
+        sparse_attribute->default_values().default_value == 12,
+        "Wrong default value" );
     sparse_attribute->set_value( 3, 3 );
     sparse_attribute->set_value( 7, 7 );
     manager.assign_attribute_value( 3, 2 );
@@ -257,18 +301,28 @@ void test_double_sparse_attribute(
 
 void test_double_array_attribute( geode::AttributeManager& manager )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = true;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< std::array< double, 3 > > attribute_values;
+    attribute_values.default_value = { { 10., 11., 12. } };
+    attribute_values.no_value = { { 0., 0., 0. } };
     const auto attribute_id =
         manager.create_attribute< geode::VariableAttribute,
             std::array< double, 3 > >(
-            "double_array", { { 10., 11., 12. } }, { true, true } );
+            "double_array", attribute_values, attribute_properties );
     auto array_attribute = manager.find_attribute< geode::VariableAttribute,
         std::array< double, 3 > >( attribute_id );
     geode::OpenGeodeBasicException::test(
-        array_attribute->default_value()[0] == 10., "Wrong default value" );
+        array_attribute->default_values().default_value[0] == 10.,
+        "Wrong default value" );
     geode::OpenGeodeBasicException::test(
-        array_attribute->default_value()[1] == 11., "Wrong default value" );
+        array_attribute->default_values().default_value[1] == 11.,
+        "Wrong default value" );
     geode::OpenGeodeBasicException::test(
-        array_attribute->default_value()[2] == 12., "Wrong default value" );
+        array_attribute->default_values().default_value[2] == 12.,
+        "Wrong default value" );
     array_attribute->set_value( 3, { { 1., 2., 3. } } );
     array_attribute->set_value( 7, { { 2., 5., 7. } } );
     manager.assign_attribute_value( 3, 2 );
@@ -320,14 +374,22 @@ void test_double_array_attribute( geode::AttributeManager& manager )
 void test_bool_variable_attribute(
     geode::AttributeManager& manager, const geode::uuid& attribute_id )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = true;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< bool > attribute_values;
+    attribute_values.default_value = false;
+    attribute_values.no_value = false;
     manager.create_attribute< geode::VariableAttribute, bool >(
-        "bool", attribute_id, false, { true, true } );
+        "bool", attribute_id, attribute_values, attribute_properties );
 
     auto variable_attribute =
         manager.find_attribute< geode::VariableAttribute, bool >(
             attribute_id );
     geode::OpenGeodeBasicException::test(
-        variable_attribute->default_value() == false, "Wrong default value" );
+        variable_attribute->default_values().default_value == false,
+        "Wrong default value" );
     variable_attribute->set_value( 3, true );
 
     const auto attribute =
@@ -527,10 +589,16 @@ geode::uuid test_generic_value( geode::AttributeManager& manager,
         manager.find_read_only_attribute< double >( double_attribute_id );
     geode::OpenGeodeBasicException::test( double_attr->generic_value( 7 ) == 7,
         "Generic value for element 7 of double attribute should be 7" );
-
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = true;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< std::array< double, 2 > > attribute_values;
+    attribute_values.default_value = {};
+    attribute_values.no_value = {};
     auto array_attr_id = manager.create_attribute< geode::VariableAttribute,
-        std::array< double, 2 > >( "array_double_2", std::array< double, 2 >(),
-        geode::AttributeProperties{} );
+        std::array< double, 2 > >(
+        "array_double_2", attribute_values, attribute_properties );
     auto array_attr = manager.find_attribute< geode::VariableAttribute,
         std::array< double, 2 > >( array_attr_id );
     array_attr->set_value( 2, { 3.1, 1.3 } );
@@ -554,6 +622,7 @@ void test_copy_manager( geode::AttributeManager& manager,
     const geode::uuid& bool_variable_attribute_id )
 {
     geode::AttributeManager manager2;
+    test_number_of_attributes( manager, 8 );
     manager2.copy( manager );
     manager2.reserve( 15 );
     test_attribute_types( manager2, bool_variable_attribute_id );
@@ -610,9 +679,16 @@ void test_multi_import_manager()
 {
     geode::AttributeManager from1;
     from1.resize( 10 );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = true;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute1_values;
+    attribute1_values.default_value = 42.;
+    attribute1_values.no_value = geode::NO_ID;
     auto attr1_from1_id =
         from1.create_attribute< geode::VariableAttribute, geode::index_t >(
-            " variable", 42, geode::AttributeProperties{} );
+            " variable", attribute1_values, attribute_properties );
     auto attr1_from1 =
         from1.find_attribute< geode::VariableAttribute, geode::index_t >(
             attr1_from1_id );
@@ -620,14 +696,20 @@ void test_multi_import_manager()
     {
         attr1_from1->set_value( i, i );
     }
+    geode::AttributeValues< double > attribute2_values;
+    attribute2_values.default_value = 1.0;
+    attribute2_values.no_value = std::numeric_limits< double >::max();
     auto attr2_from1_id =
         from1.create_attribute< geode::ConstantAttribute, double >(
-            "constant", 1.0, geode::AttributeProperties{} );
+            "constant", attribute2_values, attribute_properties );
     auto attr2_from1 = from1.find_attribute< geode::ConstantAttribute, double >(
         attr2_from1_id );
+    geode::AttributeValues< std::string > attribute3_values;
+    attribute3_values.default_value = "default";
+    attribute3_values.no_value = "no_value";
     auto attr3_from1_id =
         from1.create_attribute< geode::SparseAttribute, std::string >(
-            "sparse", "default", geode::AttributeProperties{} );
+            "sparse", attribute3_values, attribute_properties );
     auto attr3_from1 =
         from1.find_attribute< geode::SparseAttribute, std::string >(
             attr3_from1_id );
@@ -635,8 +717,12 @@ void test_multi_import_manager()
 
     geode::AttributeManager from2;
     from2.resize( 10 );
+    geode::AttributeValues< geode::index_t > second_attribute1_values;
+    second_attribute1_values.default_value = 42.;
+    second_attribute1_values.no_value = geode::NO_ID;
     from2.create_attribute< geode::VariableAttribute, geode::index_t >(
-        " variable", attr1_from1_id, 42, geode::AttributeProperties{} );
+        " variable", attr1_from1_id, second_attribute1_values,
+        attribute_properties );
     auto attr1_from2 =
         from2.find_attribute< geode::VariableAttribute, geode::index_t >(
             attr1_from1_id );
@@ -644,12 +730,18 @@ void test_multi_import_manager()
     {
         attr1_from2->set_value( i, from2.nb_elements() - i );
     }
-    from2.create_attribute< geode::ConstantAttribute, double >(
-        "constant", attr2_from1_id, 2.0, geode::AttributeProperties{} );
+    geode::AttributeValues< double > second_attribute2_values;
+    second_attribute2_values.default_value = 2.0;
+    second_attribute2_values.no_value = std::numeric_limits< double >::max();
+    from2.create_attribute< geode::ConstantAttribute, double >( "constant",
+        attr2_from1_id, second_attribute2_values, attribute_properties );
     auto attr2_from2 = from2.find_attribute< geode::ConstantAttribute, double >(
         attr2_from1_id );
+    geode::AttributeValues< std::string > second_attribute3_values;
+    second_attribute3_values.default_value = "another_default";
+    second_attribute3_values.no_value = "another_no_value";
     from2.create_attribute< geode::SparseAttribute, std::string >( "sparse",
-        attr3_from1_id, "another_default", geode::AttributeProperties{} );
+        attr3_from1_id, second_attribute3_values, attribute_properties );
     auto attr3_from2 =
         from2.find_attribute< geode::SparseAttribute, std::string >(
             attr3_from1_id );

--- a/tests/geometry/test-point.cpp
+++ b/tests/geometry/test-point.cpp
@@ -65,18 +65,28 @@ void test_interpolation()
 {
     geode::AttributeManager manager;
     manager.resize( 10 );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::Point< 3 > > attribute_values;
+    attribute_values.default_value = geode::Point3D{ { 10., 11., 12. } };
+    attribute_values.no_value = geode::Point3D{};
     auto attribute_id =
         manager.create_attribute< geode::VariableAttribute, geode::Point< 3 > >(
-            "points", geode::Point3D{ { 10., 11., 12. } }, { false, true } );
+            "points", attribute_values, attribute_properties );
     auto attribute =
         manager.find_attribute< geode::VariableAttribute, geode::Point< 3 > >(
             attribute_id );
     geode::OpenGeodeGeometryException::test(
-        attribute->default_value().value( 0 ) == 10., "Wrong default value" );
+        attribute->default_values().default_value.value( 0 ) == 10.,
+        "Wrong default value" );
     geode::OpenGeodeGeometryException::test(
-        attribute->default_value().value( 1 ) == 11., "Wrong default value" );
+        attribute->default_values().default_value.value( 1 ) == 11.,
+        "Wrong default value" );
     geode::OpenGeodeGeometryException::test(
-        attribute->default_value().value( 2 ) == 12., "Wrong default value" );
+        attribute->default_values().default_value.value( 2 ) == 12.,
+        "Wrong default value" );
     attribute->set_value( 3, geode::Point3D{ { 1., 2., 3. } } );
     attribute->set_value( 7, geode::Point3D{ { 2., 5., 7. } } );
     manager.interpolate_attribute_value( { { 1, 7 }, { 0.5, 0.3 } }, 4 );

--- a/tests/image/test-colors.cpp
+++ b/tests/image/test-colors.cpp
@@ -46,17 +46,27 @@ void test_color_attribute()
 {
     geode::AttributeManager manager;
     manager.resize( 1 );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::RGBColor > attribute_values;
+    attribute_values.default_value = geode::RGBColor{};
+    attribute_values.no_value = geode::RGBColor{};
     const auto rgb_attribute_id =
         manager.create_attribute< geode::VariableAttribute, geode::RGBColor >(
-            "rgb_color", geode::RGBColor{}, geode::AttributeProperties{} );
+            "rgb_color", attribute_values, attribute_properties );
     auto rgb_attribute =
         manager.find_attribute< geode::VariableAttribute, geode::RGBColor >(
             rgb_attribute_id );
     rgb_attribute->set_value( 0, { 3, 254, 68 } );
+    geode::AttributeValues< geode::GreyscaleColor > grey_attribute_values;
+    grey_attribute_values.default_value = geode::GreyscaleColor{};
+    grey_attribute_values.no_value = geode::GreyscaleColor{};
     const auto greyscale_attribute_id =
         manager.create_attribute< geode::VariableAttribute,
-            geode::GreyscaleColor >( "greyscale_color", geode::GreyscaleColor{},
-            geode::AttributeProperties{} );
+            geode::GreyscaleColor >(
+            "greyscale_color", grey_attribute_values, attribute_properties );
     auto greyscale_attribute = manager.find_attribute< geode::VariableAttribute,
         geode::GreyscaleColor >( greyscale_attribute_id );
     greyscale_attribute->set_value( 0, geode::GreyscaleColor{ 67 } );

--- a/tests/mesh/test-convert-surface.cpp
+++ b/tests/mesh/test-convert-surface.cpp
@@ -115,11 +115,17 @@ void convert_grid_to_surface()
         absl::StrCat( geode::DATA_PATH, "old_regular_grid.og_rgd2d" ) );
     const auto old_regular_grid_surface =
         geode::convert_grid_into_triangulated_surface( *old_regular_grid );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::Point2D > attribute_values;
+    attribute_values.default_value = geode::Point2D{};
+    attribute_values.no_value = geode::Point2D{};
     auto test_attribute_id =
         old_regular_grid_surface->vertex_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::Point2D >(
-                "test", geode::Point2D{ { 0., 0. } },
-                geode::AttributeProperties{} );
+                "test", attribute_values, attribute_properties );
     auto test_attribute =
         old_regular_grid_surface->vertex_attribute_manager()
             .find_attribute< geode::VariableAttribute, geode::Point2D >(
@@ -129,9 +135,8 @@ void convert_grid_to_surface()
             *old_regular_grid )
             .value();
     old_regular_grid_surface2->vertex_attribute_manager()
-        .create_attribute< geode::VariableAttribute, geode::Point2D >( "test",
-            test_attribute_id, geode::Point2D{ { 0., 0. } },
-            geode::AttributeProperties{} );
+        .create_attribute< geode::VariableAttribute, geode::Point2D >(
+            "test", test_attribute_id, attribute_values, attribute_properties );
     auto test_attribute2 =
         old_regular_grid_surface2->vertex_attribute_manager()
             .find_attribute< geode::VariableAttribute, geode::Point2D >(

--- a/tests/mesh/test-edged-curve.cpp
+++ b/tests/mesh/test-edged-curve.cpp
@@ -311,9 +311,17 @@ void test_edge_requests( const geode::EdgedCurve3D& edged_curve,
 
 void test_clone( const geode::EdgedCurve3D& edged_curve )
 {
-    auto attribute_id = edged_curve.edge_attribute_manager()
-                            .create_attribute< geode::VariableAttribute, int >(
-                                "edge", 0, geode::AttributeProperties{} );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< int > attribute_values;
+    attribute_values.default_value = 0;
+    attribute_values.no_value = 0;
+    auto attribute_id =
+        edged_curve.edge_attribute_manager()
+            .create_attribute< geode::VariableAttribute, int >(
+                "edge", attribute_values, attribute_properties );
     auto attribute =
         edged_curve.edge_attribute_manager()
             .find_attribute< geode::VariableAttribute, int >( attribute_id );

--- a/tests/mesh/test-generic-mesh-accessor.cpp
+++ b/tests/mesh/test-generic-mesh-accessor.cpp
@@ -51,9 +51,16 @@ std::unique_ptr< geode::EdgedCurve3D > create_edged_curve(
     builder->create_point( geode::Point3D{ { 0, 1, 0 } } );
     builder->create_edge( 0, 1 );
     builder->create_edge( 0, 2 );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = 2;
+    attribute_values.no_value = 0;
     edged_curve->edge_attribute_manager()
         .create_attribute< geode::VariableAttribute, geode::index_t >(
-            "edge", attribute_id, 2, geode::AttributeProperties{} );
+            "edge", attribute_id, attribute_values, attribute_properties );
     auto attribute =
         edged_curve->edge_attribute_manager()
             .find_attribute< geode::VariableAttribute, geode::index_t >(
@@ -74,9 +81,16 @@ std::unique_ptr< geode::TriangulatedSurface2D > create_surface(
     builder->create_triangle( { 0, 1, 2 } );
     builder->create_triangle( { 0, 3, 1 } );
     builder->compute_polygon_adjacencies();
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = 2;
+    attribute_values.no_value = 0;
     surface->polygon_attribute_manager()
         .create_attribute< geode::VariableAttribute, geode::index_t >(
-            "surface", attribute_id, 2, geode::AttributeProperties{} );
+            "surface", attribute_id, attribute_values, attribute_properties );
     auto attribute =
         surface->polygon_attribute_manager()
             .find_attribute< geode::VariableAttribute, geode::index_t >(
@@ -98,9 +112,16 @@ std::unique_ptr< geode::TetrahedralSolid3D > create_solid(
     builder->create_tetrahedron( { 0, 1, 2, 3 } );
     builder->create_tetrahedron( { 3, 2, 4, 1 } );
     builder->compute_polyhedron_adjacencies();
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = 2;
+    attribute_values.no_value = 0;
     solid->polyhedron_attribute_manager()
         .create_attribute< geode::VariableAttribute, geode::index_t >(
-            "solid", attribute_id, 2, geode::AttributeProperties{} );
+            "solid", attribute_id, attribute_values, attribute_properties );
     auto attribute =
         solid->polyhedron_attribute_manager()
             .find_attribute< geode::VariableAttribute, geode::index_t >(

--- a/tests/mesh/test-gradient-computation.cpp
+++ b/tests/mesh/test-gradient-computation.cpp
@@ -48,10 +48,17 @@ void test_gradient_grid2D()
     auto builder = geode::RegularGridBuilder< 2 >::create( *grid );
     builder->initialize_grid( geode::Point2D{ { 0, 0 } }, { 3, 3 },
         { geode::Vector2D{ { 1, 0 } }, geode::Vector2D{ { 0, 1 } } } );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< double > attribute_values;
+    attribute_values.default_value = 0;
+    attribute_values.no_value = 0;
     auto attribute_id =
         grid->vertex_attribute_manager()
             .create_attribute< geode::VariableAttribute, double >(
-                "scalar_function", 0, geode::AttributeProperties{} );
+                "scalar_function", attribute_values, attribute_properties );
     auto attribute =
         grid->vertex_attribute_manager()
             .find_attribute< geode::VariableAttribute, double >( attribute_id );
@@ -101,10 +108,17 @@ void test_gradient_triangulated_surface2D()
     builder->create_polygon( { 6, 9, 8 } );
     builder->create_polygon( { 5, 6, 8 } );
     builder->compute_polygon_adjacencies();
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< double > attribute_values;
+    attribute_values.default_value = 0;
+    attribute_values.no_value = 0;
     auto attribute_id =
         surface->vertex_attribute_manager()
             .create_attribute< geode::VariableAttribute, double >(
-                "scalar_function", 0, geode::AttributeProperties{} );
+                "scalar_function", attribute_values, attribute_properties );
     auto attribute =
         surface->vertex_attribute_manager()
             .find_attribute< geode::VariableAttribute, double >( attribute_id );
@@ -130,10 +144,17 @@ void test_gradient_grid3D()
     builder->initialize_grid( geode::Point3D{ { 0, 0, 0 } }, { 2, 2, 2 },
         { geode::Vector3D{ { 1, 0, 0 } }, geode::Vector3D{ { 0, 1, 0 } },
             geode::Vector3D{ { 0, 0, 1 } } } );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< double > attribute_values;
+    attribute_values.default_value = 0;
+    attribute_values.no_value = 0;
     auto attribute_id =
         grid->vertex_attribute_manager()
             .create_attribute< geode::VariableAttribute, double >(
-                "scalar_function", 0, geode::AttributeProperties{} );
+                "scalar_function", attribute_values, attribute_properties );
     auto attribute =
         grid->vertex_attribute_manager()
             .find_attribute< geode::VariableAttribute, double >( attribute_id );

--- a/tests/mesh/test-hausdorff-distance.cpp
+++ b/tests/mesh/test-hausdorff-distance.cpp
@@ -14,6 +14,7 @@
 void test()
 {
     geode::OpenGeodeMeshLibrary::initialize();
+    geode::Logger::set_level( geode::Logger::LEVEL::debug );
     const auto initial_mesh_filename =
         absl::StrCat( geode::DATA_PATH, "Armadillo.og_tsf3d" );
     const auto mesh_A =

--- a/tests/mesh/test-light-regular-grid.cpp
+++ b/tests/mesh/test-light-regular-grid.cpp
@@ -332,10 +332,17 @@ void test_closest_vertex( const geode::LightRegularGrid3D& grid )
 
 void test_attribute( const geode::LightRegularGrid3D& grid )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< double > attribute_values;
+    attribute_values.default_value = -1;
+    attribute_values.no_value = -1;
     auto attribute_id =
         grid.cell_attribute_manager()
             .create_attribute< geode::VariableAttribute, double >(
-                "test", -1, geode::AttributeProperties{} );
+                "test", attribute_values, attribute_properties );
     auto attribute =
         grid.cell_attribute_manager()
             .find_attribute< geode::VariableAttribute, double >( attribute_id );

--- a/tests/mesh/test-point-set.cpp
+++ b/tests/mesh/test-point-set.cpp
@@ -84,9 +84,17 @@ void test_bounding_box( const geode::PointSet3D& point_set )
 
 geode::uuid test_create_vertex_attribute( const geode::PointSet3D& point_set )
 {
-    auto attribute_id = point_set.vertex_attribute_manager()
-                            .create_attribute< geode::ConstantAttribute, bool >(
-                                "bool", true, geode::AttributeProperties{} );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< bool > attribute_values;
+    attribute_values.default_value = true;
+    attribute_values.no_value = true;
+    auto attribute_id =
+        point_set.vertex_attribute_manager()
+            .create_attribute< geode::ConstantAttribute, bool >(
+                "bool", attribute_values, attribute_properties );
     const auto attribute =
         point_set.vertex_attribute_manager()
             .find_attribute< geode::ConstantAttribute, bool >( attribute_id );

--- a/tests/mesh/test-polygonal-surface.cpp
+++ b/tests/mesh/test-polygonal-surface.cpp
@@ -71,10 +71,17 @@ void test_bounding_box( const geode::PolygonalSurface3D& polygonal_surface )
 geode::uuid test_create_vertex_attribute(
     const geode::PolygonalSurface3D& polygonal_surface )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::PolygonEdge > attribute_values;
+    attribute_values.default_value = geode::PolygonEdge{};
+    attribute_values.no_value = geode::PolygonEdge{};
     auto attribute_id =
         polygonal_surface.vertex_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::PolygonEdge >(
-                "test", geode::PolygonEdge{}, geode::AttributeProperties{} );
+                "test", attribute_values, attribute_properties );
     auto attribute =
         polygonal_surface.vertex_attribute_manager()
             .find_attribute< geode::VariableAttribute, geode::PolygonEdge >(
@@ -228,11 +235,18 @@ void test_create_polygons( const geode::PolygonalSurface3D& polygonal_surface,
 geode::uuid test_create_edge_attribute(
     const geode::PolygonalSurface3D& polygonal_surface )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = geode::NO_ID;
+    attribute_values.no_value = geode::NO_ID;
     auto attribute_id =
         polygonal_surface.edges()
             .edge_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::index_t >(
-                "edges", geode::NO_ID, geode::AttributeProperties{} );
+                "edges", attribute_values, attribute_properties );
     auto attribute =
         polygonal_surface.edges()
             .edge_attribute_manager()

--- a/tests/mesh/test-polyhedral-solid.cpp
+++ b/tests/mesh/test-polyhedral-solid.cpp
@@ -130,11 +130,18 @@ void test_create_polyhedra( const geode::PolyhedralSolid3D& polyhedral_solid,
 geode::uuid test_create_facet_attribute(
     const geode::PolyhedralSolid3D& polyhedral_solid )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = geode::NO_ID;
+    attribute_values.no_value = geode::NO_ID;
     auto attribute_id =
         polyhedral_solid.facets()
             .facet_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::index_t >(
-                "facet_attribute", geode::NO_ID, geode::AttributeProperties{} );
+                "facet_attribute", attribute_values, attribute_properties );
     auto attribute =
         polyhedral_solid.facets()
             .facet_attribute_manager()
@@ -150,11 +157,18 @@ geode::uuid test_create_facet_attribute(
 geode::uuid test_create_edge_attribute(
     const geode::PolyhedralSolid3D& polyhedral_solid )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = geode::NO_ID;
+    attribute_values.no_value = geode::NO_ID;
     auto attribute_id =
         polyhedral_solid.edges()
             .edge_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::index_t >(
-                "test", geode::NO_ID, geode::AttributeProperties{} );
+                "test", attribute_values, attribute_properties );
     auto attribute =
         polyhedral_solid.edges()
             .edge_attribute_manager()
@@ -541,11 +555,17 @@ void test_normals()
 geode::uuid test_create_vertex_attribute(
     const geode::PolyhedralSolid3D& polyhedral_solid )
 {
-    auto attribute_id =
-        polyhedral_solid.vertex_attribute_manager()
-            .create_attribute< geode::VariableAttribute,
-                geode::PolyhedronFacetVertex >( "test",
-                geode::PolyhedronFacetVertex{}, geode::AttributeProperties{} );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::PolyhedronFacetVertex > attribute_values;
+    attribute_values.default_value = geode::PolyhedronFacetVertex{};
+    attribute_values.no_value = geode::PolyhedronFacetVertex{};
+    auto attribute_id = polyhedral_solid.vertex_attribute_manager()
+                            .create_attribute< geode::VariableAttribute,
+                                geode::PolyhedronFacetVertex >( "test",
+                                attribute_values, attribute_properties );
     auto attribute = polyhedral_solid.vertex_attribute_manager()
                          .find_attribute< geode::VariableAttribute,
                              geode::PolyhedronFacetVertex >( attribute_id );

--- a/tests/mesh/test-regular-grid.cpp
+++ b/tests/mesh/test-regular-grid.cpp
@@ -353,17 +353,28 @@ void test_closest_vertex( const geode::RegularGrid3D& grid )
 
 void test_clone( const geode::RegularGrid3D& grid )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< int > attribute_values_int;
+    attribute_values_int.default_value = 0;
+    attribute_values_int.no_value = 0;
     auto attribute_id =
         grid.polyhedron_attribute_manager()
             .create_attribute< geode::VariableAttribute, int >(
-                "int_attribute", 0, geode::AttributeProperties{} );
+                "int_attribute", attribute_values_int, attribute_properties );
     auto attribute =
         grid.polyhedron_attribute_manager()
             .find_attribute< geode::VariableAttribute, int >( attribute_id );
+    geode::AttributeValues< double > attribute_values_double;
+    attribute_values_double.default_value = 0;
+    attribute_values_double.no_value = 0;
     auto attribute_d_id =
         grid.vertex_attribute_manager()
             .create_attribute< geode::VariableAttribute, double >(
-                "double_attribute", 0, geode::AttributeProperties{} );
+                "double_attribute", attribute_values_double,
+                attribute_properties );
     auto attribute_d = grid.vertex_attribute_manager()
                            .find_attribute< geode::VariableAttribute, double >(
                                attribute_d_id );

--- a/tests/mesh/test-tetrahedral-solid.cpp
+++ b/tests/mesh/test-tetrahedral-solid.cpp
@@ -339,11 +339,18 @@ void test_backward_io( const std::string& filename )
 
 void test_clone( const geode::TetrahedralSolid3D& solid )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = 0;
+    attribute_values.no_value = geode::NO_ID;
     auto attr_from_id =
         solid.facets()
             .facet_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::index_t >(
-                "facet_id", 0, geode::AttributeProperties{} );
+                "facet_id", attribute_values, attribute_properties );
     auto attr_from =
         solid.facets()
             .facet_attribute_manager()
@@ -357,7 +364,7 @@ void test_clone( const geode::TetrahedralSolid3D& solid )
         solid.edges()
             .edge_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::index_t >(
-                "edge_id", 0, geode::AttributeProperties{} );
+                "edge_id", attribute_values, attribute_properties );
     auto attr_edge_from =
         solid.edges()
             .edge_attribute_manager()

--- a/tests/mesh/test-triangulated-surface.cpp
+++ b/tests/mesh/test-triangulated-surface.cpp
@@ -267,11 +267,18 @@ void test_backward_io( const std::string& filename )
 }
 void test_clone( const geode::TriangulatedSurface3D& surface )
 {
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< geode::index_t > attribute_values;
+    attribute_values.default_value = 0;
+    attribute_values.no_value = geode::NO_ID;
     auto attr_from_id =
         surface.edges()
             .edge_attribute_manager()
             .create_attribute< geode::VariableAttribute, geode::index_t >(
-                "edge_id", 0, geode::AttributeProperties{} );
+                "edge_id", attribute_values, attribute_properties );
     auto attr_from =
         surface.edges()
             .edge_attribute_manager()

--- a/tests/model/test-relationships.cpp
+++ b/tests/model/test-relationships.cpp
@@ -167,10 +167,17 @@ void test_attributes( const geode::Relationships& relations,
     geode::OpenGeodeModelException::test(
         std::get< 1 >( output ).id() == uuids[0],
         "Wrong relation uuids from index" );
+    geode::AttributeProperties attribute_properties;
+    attribute_properties.assignable = false;
+    attribute_properties.interpolable = true;
+    attribute_properties.transferable = true;
+    geode::AttributeValues< int > attribute_values;
+    attribute_values.default_value = 0;
+    attribute_values.no_value = 0;
     auto relation_att_id =
         relations.relation_attribute_manager()
             .create_attribute< geode::VariableAttribute, int >(
-                "int", 0, geode::AttributeProperties{} );
+                "int", attribute_values, attribute_properties );
     const auto relation_att =
         relations.relation_attribute_manager()
             .find_attribute< geode::VariableAttribute, int >( relation_att_id );


### PR DESCRIPTION
BREAKING CHANGE: create_attribute now requires an additional parameter to specify the no-value property.